### PR TITLE
Omo

### DIFF
--- a/?.js
+++ b/?.js
@@ -544,8 +544,18 @@ try {
                 console.error('[PLOGME HOOK ERROR]', err?.message || err);
             }
 
-            const { handleIncomingMessage } = require('./src/Commands/Core/\u275A.js');
-            await handleIncomingMessage(sock, m, mek);
+            // ── Legacy chatbot brain (❚.js) — PLOGME replaced the old
+            //    chatbot, so an explicit ".plogme off" in this chat must
+            //    silence it too, otherwise the old brain keeps auto-replying
+            //    after the toggle. (@crysnovax—FIX10-08-26)
+            try {
+                if (plogmeCmd.isEnabled(m.chat) || !plogmeCmd.hasExplicitToggle(m.chat)) {
+                    const { handleIncomingMessage } = require('./src/Commands/Core/\u275A.js');
+                    await handleIncomingMessage(sock, m, mek);
+                }
+            } catch (err) {
+                console.error('[LEGACY CHATBOT ERROR]', err?.message || err);
+            }
 
             try {
                 const crysnova = require('./src/Commands/AI/crysnova.js');

--- a/src/Commands/AI/plogme.js
+++ b/src/Commands/AI/plogme.js
@@ -30,7 +30,7 @@ module.exports = {
                     return reply('`GLOBAL MODE OFF`');
                 }
                 plogme.setEnabled(m.chat, false);
-                return reply('`✘ DISABLED`');
+                return reply('`✘ DISABLED` — no auto-replies in this chat (send ' + (prefix || '.') + 'plogme on to re-enable)');
             }
             case 'mode': {
                 const mode = (args[1] || '').toLowerCase();

--- a/src/Commands/Core/plogme.js
+++ b/src/Commands/Core/plogme.js
@@ -901,15 +901,30 @@ async function execute(sock, m, opts) {
 
         const privileged = await isPrivileged(sock, m);
 
-        // Control intents — only for owner/sudo/dual. A ".plogme run ping"
+        // An EXPLICIT ".plogme off" in a chat means SILENT — no free-form AI
+        // chat. Explicit control ("plogme on", "plogme status", "plogme run
+        // ping") still works so the user can always re-enable.
+        // (@crysnovax—FIX10-08-26)
+        const explicitlyOff = hasExplicitToggle(m.chat) && !isEnabled(m.chat);
+
+        // Control intents — only for owner/sudo/dual. A "plogme run ping"
         // style message is treated the same as a bare control intent, and a
         // plain "ping" / "can you ping" / "check uptime" query auto-runs the
         // command too — no more strict phrasing. @crysnovax—FIX08-07-26
         if (privileged) {
             const body = isCommand ? text.slice(prefix.length).trim() : text;
             const isPlogmeInvocation = /^(plogme|plg|plog)(\s|$)/i.test(body);
-            const handledControl = await handleControlIntent(sock, m, opts, isPlogmeInvocation ? body : text);
-            if (handledControl) return true;
+
+            // A prefixed ".plogme <sub>" (e.g. "/plogme off") is OWNED by the
+            // router command src/Commands/AI/plogme.js, which already replied
+            // ("✖ DISABLED"). Running the control intents again made every
+            // prefixed toggle reply TWICE ("✖ DISABLED" + "⛔ PLOGME toggled
+            // OFF"). Only bare, non-prefixed phrases ("plogme off", "run
+            // ping") are handled here. (@crysnovax—FIX10-08-26)
+            if (!isCommand) {
+                const handledControl = await handleControlIntent(sock, m, opts, isPlogmeInvocation ? body : text);
+                if (handledControl) return true;
+            }
 
             // ── LLM intent brain ──
             // Anything else a privileged user says — plain chat OR an unhandled
@@ -917,8 +932,11 @@ async function execute(sock, m, opts) {
             // context ("please run the menu command for me", "create a command
             // called hi", "edit the ping command to say hi") with no hardcoded
             // phrasing. When the AI is unreachable we simply fall through to
-            // the normal chat flow below. @crysnovax—FIX09-08-26
-            if (!isCommand) {
+            // the normal chat flow below. Skipped when plogme was explicitly
+            // toggled off in this chat — off means SILENT, so "Hey" after
+            // ".plogme off" must NOT get an AI chat reply.
+            // (@crysnovax—FIX09-08-26 / FIX10-08-26)
+            if (!isCommand && !explicitlyOff) {
                 try {
                     const intent = await classifyIntent(isPlogmeInvocation ? body : text);
                     if (intent) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled PLOGME chats no longer receive automatic AI or legacy chatbot replies.
  * PLOGME control commands continue to work when automatic replies are disabled.
  * Prefixed commands are no longer processed twice or incorrectly interpreted as AI requests.
  * The disabled-chat message now displays the active command prefix and re-enable instructions.
  * Legacy chatbot failures are handled without interrupting chat processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->