### PR TITLE
Fix Baileys 2.7.4 startup auth import

### DIFF
--- a/library/connection/connection.js
+++ b/library/connection/connection.js
@@ -5,7 +5,6 @@
 
 const {
     default: makeWASocket,
-    useMultiFileAuthState,
     fetchLatestBaileysVersion,
     Browsers,
     DisconnectReason,
@@ -23,6 +22,10 @@ async function getAuthState() {
     if (!fs.existsSync(SESSION_PATH)) {
         fs.mkdirSync(SESSION_PATH, { recursive: true });
     }
+    // Baileys 2.7.4 keeps the auth helper in its Utils entrypoint. Import it
+    // directly so startup works even when a CommonJS require namespace omits
+    // star-re-exported ESM utilities.
+    const { useMultiFileAuthState } = await import('@crysnovax/baileys/lib/Utils/use-multi-file-auth-state.js');
     return await useMultiFileAuthState(SESSION_PATH);
 }
 


### PR DESCRIPTION
Fixes Cody startup with @crysnovax/baileys 2.7.4 by importing useMultiFileAuthState from the package Utils entrypoint. Includes the existing Baileys 2.7.4 update and compatibility changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication state initialization for more reliable connection setup.
  * Updated compatibility with the messaging library’s authentication utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->