### PR TITLE
Remove Baileys anti-spam socket wrapper

### DIFF
--- a/library/connection/connection.js
+++ b/library/connection/connection.js
@@ -7,8 +7,7 @@ const {
     default: makeWASocket,
     fetchLatestBaileysVersion,
     Browsers,
-    DisconnectReason,
-    wrapSocket
+    DisconnectReason
 } = require('@crysnovax/baileys');
 const { Boom } = require('@hapi/boom');
 const pino = require('pino');
@@ -177,11 +176,7 @@ async function createSocket(sessionId) {
         getMessage: null
     });
 
-    // Baileys 2.7.4 exposes wrapSocket to add anti-spam protections without
-    // changing the public socket API. Keep a graceful fallback for older builds.
-    const protectedSock = typeof wrapSocket === 'function' ? wrapSocket(sock) : sock;
-
-    return { sock: protectedSock, saveCreds, state };
+    return { sock, saveCreds, state };
 }
 
 async function clearSession() {


### PR DESCRIPTION
Removes the wrapSocket anti-spam wrapper from Cody's connection setup. The raw socket is returned again, preventing the 30-message warm-up limiter from blocking normal bot traffic. The change is already committed as 1c27c1a.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified socket creation and removed fallback socket wrapping.
  * Connections now use the underlying socket directly while retaining credential saving and connection state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->