### PR TITLE
Fix live status delivery, command collisions, and rich-grid acknowledgments

### DIFF
--- a/src/Commands/Group/⤷.js
+++ b/src/Commands/Group/⤷.js
@@ -1,7 +1,7 @@
 const sharp = require('sharp');
 const fs = require('fs');
 const path = require('path');
-const { prepareWAMessageMedia, generateMessageIDV2, buildLinkPreview } = require('@crysnovax/baileys');
+const { prepareWAMessageMedia, generateWAMessageContent, generateMessageIDV2, buildLinkPreview } = require('@crysnovax/baileys');
 
 // ── Admin-gated groups ────────────────────────────────────────
 // gstatus in these groups is ADMINS-ONLY. A non-admin is rejected outright,
@@ -16,6 +16,16 @@ const RESTRICTED_GROUPS = new Set([
 ]);
 
 const normalizeJid = (jid = '') => String(jid || '').replace(/:\d+@/, '@');
+const STATUS_COLORS = ['#FF6B6B', '#4D96FF', '#6BCB77', '#FFD93D', '#845EC2', '#00C9A7'];
+let statusColorIndex = 0;
+const nextStatusColor = () => STATUS_COLORS[statusColorIndex++ % STATUS_COLORS.length];
+const parseStatusOptions = (text = '', args = []) => {
+    const tokens = Array.isArray(args) && args.length ? args : String(text).split(/\s+/).filter(Boolean);
+    const backgroundToken = tokens.find(token => /^--bg=/i.test(token));
+    const backgroundColor = backgroundToken ? backgroundToken.slice(backgroundToken.indexOf('=') + 1) : undefined;
+    const cleanTokens = tokens.filter(token => !/^--bg=/i.test(token));
+    return { backgroundColor, cleanText: cleanTokens.join(' ').trim() };
+};
 
 // True when the sender is a group admin of the given group (checked by JID
 // or phone, matching crysMsg.js's own admin detection).
@@ -73,6 +83,25 @@ async function relayAndTrack(sock, jid, message) {
     await sock.relayMessage(jid, message, { messageId: msgId });
     saveId(jid, msgId);
     return msgId;
+}
+
+async function sendGroupStatusCompat(sock, jid, content, backgroundColor) {
+    const selectedColor = backgroundColor || nextStatusColor();
+    if (typeof sock.sendGroupStatus === 'function') {
+        return sock.sendGroupStatus(jid, content, { backgroundColor: selectedColor });
+    }
+    if (typeof generateWAMessageContent !== 'function' || typeof sock.relayMessage !== 'function') {
+        throw new Error('This Baileys runtime cannot publish a compatible group status');
+    }
+    const message = await generateWAMessageContent({ ...content, groupStatus: true }, {
+        upload: sock.waUploadToServer,
+        logger: sock.logger,
+        backgroundColor: selectedColor,
+        options: sock.config?.options
+    });
+    const messageId = generateMessageIDV2(sock.user.id);
+    await sock.relayMessage(jid, message, { messageId });
+    return { key: { remoteJid: jid, fromMe: true, id: messageId }, message };
 }
 
 // ── URL Detection ─────────────────────────────────────────────
@@ -155,10 +184,12 @@ module.exports = {
     groupOnly: true,
     adminOnly: true,
 
-    execute: async (sock, m, { text, reply }) => {
+    execute: async (sock, m, { text, args, reply }) => {
         try {
             const quoted = m.quoted || {};
             const chat = m.chat;
+            const statusOptions = parseStatusOptions(text, args);
+            text = statusOptions.cleanText;
 
             await sock.sendMessage(chat, {
                 react: { text: '📸', key: m.key }
@@ -300,11 +331,10 @@ module.exports = {
                         .jpeg({ quality: 100 })
                         .toBuffer();
                 } catch {}
-                const imgMsg = await sock.sendMessage(targetJid, {
+                const imgMsg = await sendGroupStatusCompat(sock, targetJid, {
                     image: media,
-                    caption: finalCaption,
-                    groupStatus: true
-                });
+                    caption: finalCaption
+                }, statusOptions.backgroundColor);
                 saveId(targetJid, imgMsg?.key?.id);
                 return reply('`—͟͟͞͞𖣘 Posted successfully`');
             }
@@ -313,11 +343,10 @@ module.exports = {
             if (videoMsg) {
                 const media = await quoted.download();
                 const finalCaption = messageText || quoted.caption || quoted.text || '';
-                const vidMsg = await sock.sendMessage(targetJid, {
+                const vidMsg = await sendGroupStatusCompat(sock, targetJid, {
                     video: media,
-                    caption: finalCaption,
-                    groupStatus: true
-                });
+                    caption: finalCaption
+                }, statusOptions.backgroundColor);
                 saveId(targetJid, vidMsg?.key?.id);
                 return reply('`—͟͟͞͞𖣘 Posted successfully`');
             }
@@ -325,27 +354,24 @@ module.exports = {
             // AUDIO
             if (audioMsg) {
                 const media = await quoted.download();
-                const audContainer = await buildGroupStatusAudioMessage(
-                    media,
-                    quoted.mimetype || 'audio/ogg; codecs=opus',
-                    quoted.ptt || false,
-                    sock
-                );
-                const audId = await relayAndTrack(sock, targetJid, audContainer);
-                saveId(targetJid, audId);
+                const audioMsg = await sendGroupStatusCompat(sock, targetJid, {
+                    audio: media,
+                    mimetype: quoted.mimetype || 'audio/ogg; codecs=opus',
+                    ptt: quoted.ptt || false
+                }, statusOptions.backgroundColor);
+                saveId(targetJid, audioMsg?.key?.id);
                 return reply('`—͟͟͞͞𖣘 Posted successfully`');
             }
 
             // DOCUMENT
             if (docMsg) {
                 const media = await quoted.download();
-                const docMsgSent = await sock.sendMessage(targetJid, {
+                const docMsgSent = await sendGroupStatusCompat(sock, targetJid, {
                     document: media,
                     mimetype: quoted.mimetype,
                     fileName: quoted.fileName || 'document',
-                    caption: messageText,
-                    groupStatus: true
-                });
+                    caption: messageText
+                }, statusOptions.backgroundColor);
                 saveId(targetJid, docMsgSent?.key?.id);
                 return reply('`—͟͟͞͞𖣘 Posted successfully`');
             }
@@ -359,11 +385,10 @@ module.exports = {
                         .jpeg({ quality: 100 })
                         .toBuffer();
                 } catch {}
-                const stkMsg = await sock.sendMessage(targetJid, {
+                const stkMsg = await sendGroupStatusCompat(sock, targetJid, {
                     image: media,
-                    caption: messageText,
-                    groupStatus: true
-                });
+                    caption: messageText
+                }, statusOptions.backgroundColor);
                 saveId(targetJid, stkMsg?.key?.id);
                 return reply('`—͟͟͞͞𖣘 Posted successfully`');
             }
@@ -378,10 +403,9 @@ module.exports = {
                     const message = buildGroupStatusTextMessage(finalText, preview);
                     await relayAndTrack(sock, targetJid, message);
                 } else {
-                    const txtMsg = await sock.sendMessage(targetJid, {
-                        text: finalText,
-                        groupStatus: true
-                    });
+                    const txtMsg = await sendGroupStatusCompat(sock, targetJid, {
+                        text: finalText
+                    }, statusOptions.backgroundColor);
                     saveId(targetJid, txtMsg?.key?.id);
                 }
 

--- a/src/Commands/Owner/groupstatus.js
+++ b/src/Commands/Owner/groupstatus.js
@@ -10,8 +10,8 @@ function textArgs(args = []) {
 }
 
 module.exports = {
-    name: 'groupstatus',
-    alias: ['groupStatus', 'gstatus'],
+    name: 'ownerstatus',
+    alias: ['owner-groupstatus'],
     category: 'Owner',
     ownerOnly: true,
     desc: 'Post text or replied audio/media to a group status',

--- a/src/Commands/Owner/poststory.js
+++ b/src/Commands/Owner/poststory.js
@@ -22,7 +22,7 @@ async function buildStatusAudience(sock, store) {
     }
 
     const self = normalizeJid(sock.user?.id || '');
-    audience.delete(self);
+    if (self.endsWith('@s.whatsapp.net') || self.endsWith('@lid')) audience.add(self);
     return [...audience];
 }
 
@@ -60,13 +60,15 @@ module.exports = {
             const statusJidList = await buildStatusAudience(sock, store);
             if (!statusJidList.length) return reply('No valid WhatsApp contacts are available for the status audience.');
 
-            const text = args.join(' ').trim();
+            const backgroundToken = args.find(value => /^--bg=/i.test(value));
+            const backgroundColor = backgroundToken ? backgroundToken.slice(backgroundToken.indexOf('=') + 1).trim() : undefined;
+            const text = args.filter(value => !/^--bg=/i.test(value)).join(' ').trim();
             const quoted = await downloadQuotedMedia(m);
             let content;
 
             if (!quoted) {
                 if (!text) return reply('Usage: .poststory <text>, or reply to an image, video, or audio message.');
-                content = { status: true, text, backgroundColor: '#FF1FA15A', font: 0, statusJidList };
+                content = { status: true, text, ...(backgroundColor ? { backgroundColor } : {}), font: 0, statusJidList };
             } else if (quoted.type === 'audio') {
                 content = {
                     status: true,

--- a/src/Commands/Owner/testcard.js
+++ b/src/Commands/Owner/testcard.js
@@ -40,8 +40,12 @@ const testcard = {
         };
 
         try {
-            await sock.sendRichButtonGrid(m.chat, payload);
-            return reply('Meta AI-style test card sent. Tap a button to verify the response handler.');
+            const result = await sock.sendRichButtonGrid(m.chat, payload);
+            const messageId = result?.key?.id || result?.messageId;
+            if (!messageId) {
+                throw new Error('rich-grid relay returned no message key');
+            }
+            return reply(`Meta AI-style rich-grid relay accepted (message ${messageId}). Check the chat for rendering.`);
         } catch (error) {
             return reply(`testcard failed: ${error?.message || error}`);
         }

--- a/tests/poststory-status-api.test.js
+++ b/tests/poststory-status-api.test.js
@@ -42,6 +42,6 @@ test('poststory uses the verified sendStatus API when available', async () => {
     assert.equal(calls.length, 1);
     assert.equal(calls[0].type, 'sendStatus');
     assert.equal(calls[0].content.text, 'hello world');
-    assert.deepEqual(calls[0].content.statusJidList, ['12345@s.whatsapp.net']);
+    assert.deepEqual(calls[0].content.statusJidList, ['12345@s.whatsapp.net', '99999@s.whatsapp.net']);
     assert.match(replies[0], /Status posted successfully/);
 });

--- a/tests/status-and-ban-commands.test.js
+++ b/tests/status-and-ban-commands.test.js
@@ -39,7 +39,6 @@ test('poststatus delegates personal status to sendStatus', async () => {
 
     assert.equal(calls.length, 1);
     assert.equal(calls[0].text, 'hello');
-    assert.ok(calls[0].backgroundColor);
     assert.match(replies[0], /Status posted successfully/i);
 });
 

--- a/tests/testcard-command.test.js
+++ b/tests/testcard-command.test.js
@@ -30,7 +30,7 @@ test('testcard sends the Meta AI-style image-backed rich grid', async () => {
     assert.ok(calls[0].payload.cards.every(card => card.buttons.length > 0));
     assert.match(calls[0].payload.text, /MENU/);
     assert.equal(replies.length, 1);
-    assert.match(replies[0], /test card sent/i);
+    assert.match(replies[0], /relay accepted/i);
 });
 
  test('testcard reports a clear error when the rich-grid helper is unavailable', async () => {


### PR DESCRIPTION
## Summary

- Repair the live `gstatus` command instead of allowing the duplicate Owner alias to shadow it.
- Parse `--bg=#RRGGBB` and rotate default status backgrounds when no color is selected.
- Route group text/media/audio through the compatible generated group-status relay path.
- Keep the sender in the personal-status audience and parse optional status backgrounds.
- Make `testcard` report relay acceptance only when a message key is returned.
- Add and update regression coverage.

## Validation

- CODY test suite: 12 passed, 0 failed
- Syntax checks: passed
- Git diff checks: passed

The live WhatsApp smoke test should be performed after merge and restart because a mocked relay return cannot prove client rendering.