### PR TITLE
feat: harden status UX and PLOGME workspace tools

### DIFF
--- a/src/Commands/AI/plogme.js
+++ b/src/Commands/AI/plogme.js
@@ -79,7 +79,15 @@ module.exports = {
 ` +
             `│ • plogme restart — restart the bot
 ` +
-            `│ • plogme dev on|off — developer mode
+            `│ • .plogme dev on|off (developer mode)
+` +
+            `│ • Ask: "start a mission to fix X" / "show my missions"
+` +
+            `│ • Ask: "suggest/install dependency <package>"
+` +
+            `│ • Ask: "index the project" / "run a health check"
+` +
+            `│ • Ask: "research <topic> on the web"
 ` +
             `╰──────────────────`;
 

--- a/src/Commands/Core/plogme-dependencies.js
+++ b/src/Commands/Core/plogme-dependencies.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT = process.cwd();
+const PACKAGE_FILE = path.join(ROOT, 'package.json');
+const SAFE_SPEC = /^(?:@?[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*(?:@[a-z0-9._*+~^<>= -]+)?$/i;
+
+function packageSpec(raw) {
+    const spec = String(raw || '').trim().replace(/^npm\s+/i, '');
+    if (!spec || spec.startsWith('-') || spec.includes('&&') || spec.includes(';') || spec.includes('|') || spec.includes('..')) return null;
+    return SAFE_SPEC.test(spec) ? spec : null;
+}
+
+function readManifest() {
+    try { return JSON.parse(fs.readFileSync(PACKAGE_FILE, 'utf8')); } catch { return {}; }
+}
+
+function localStatus(raw) {
+    const spec = packageSpec(raw);
+    if (!spec) return { ok: false, error: 'Invalid package name or version spec' };
+    const name = spec.startsWith('@') ? spec.slice(0, spec.indexOf('@', 1) > 0 ? spec.indexOf('@', 1) : spec.length) : spec.split('@')[0];
+    const manifest = readManifest();
+    const declared = manifest.dependencies?.[name] || manifest.devDependencies?.[name] || null;
+    let installed = null;
+    try { installed = require(path.join(ROOT, 'node_modules', name, 'package.json')).version; } catch {}
+    return { ok: true, name, spec, declared, installed, missing: !installed };
+}
+
+async function registryInfo(raw) {
+    const spec = packageSpec(raw);
+    if (!spec) return { ok: false, error: 'Invalid package name or version spec' };
+    const name = spec.startsWith('@') ? spec.slice(0, spec.indexOf('@', 1) > 0 ? spec.indexOf('@', 1) : spec.length) : spec.split('@')[0];
+    try {
+        const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(name)}`, { headers: { accept: 'application/json' } });
+        if (!response.ok) return { ok: false, error: `npm registry returned ${response.status}` };
+        const data = await response.json();
+        const latest = data['dist-tags']?.latest || null;
+        const version = spec.includes('@', 1) ? spec.slice(spec.indexOf('@', 1) + 1) : latest;
+        return { ok: true, name, requested: spec, latest, version, description: data.description || '', homepage: data.homepage || '', deprecated: data.versions?.[version]?.deprecated || null };
+    } catch (error) {
+        return { ok: false, error: error.message };
+    }
+}
+
+function install(raw, options = {}) {
+    const spec = packageSpec(raw);
+    if (!spec) return { ok: false, error: 'Invalid package name or version spec' };
+    if (options.dryRun) return { ok: true, dryRun: true, command: ['install', '--save', spec] };
+    const result = spawnSync('npm', ['install', '--save', spec], {
+        cwd: ROOT,
+        encoding: 'utf8',
+        timeout: Number(options.timeout || 120000),
+        maxBuffer: 4 * 1024 * 1024,
+        windowsHide: true
+    });
+    const output = `${result.stdout || ''}${result.stderr || ''}`.slice(-6000);
+    return {
+        ok: result.status === 0,
+        spec,
+        status: result.status,
+        signal: result.signal || null,
+        output,
+        error: result.error?.message || (result.status === 0 ? null : 'npm install failed')
+    };
+}
+
+module.exports = { packageSpec, localStatus, registryInfo, install };

--- a/src/Commands/Core/plogme-health.js
+++ b/src/Commands/Core/plogme-health.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = process.cwd();
+const CRITICAL_FILES = ['index.js', 'src/Plugin/crysLoadCmd.js', 'src/Plugin/crysMsg.js', 'src/Commands/Core/plogme.js'];
+
+function check(name, ok, details = '') { return { name, ok: !!ok, details: String(details || '') }; }
+
+function runHealthChecks(options = {}) {
+    const checks = [];
+    checks.push(check('runtime', Number(process.versions.node.split('.')[0]) >= 20, `Node ${process.version}`));
+    checks.push(check('project-root', fs.existsSync(path.join(ROOT, 'package.json')), ROOT));
+    let packageData = {};
+    try { packageData = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')); checks.push(check('package-json', true, `${packageData.name || 'unknown'}@${packageData.version || 'unknown'}`)); } catch (error) { checks.push(check('package-json', false, error.message)); }
+    for (const rel of CRITICAL_FILES) {
+        const abs = path.join(ROOT, rel);
+        let valid = fs.existsSync(abs);
+        let details = valid ? 'present' : 'missing';
+        if (valid && rel.endsWith('.js') && options.syntax !== false) {
+            try { execFileSync(process.execPath, ['--check', abs], { cwd: ROOT, timeout: 20000, stdio: 'pipe' }); details = 'present and syntax-valid'; }
+            catch (error) { valid = false; details = String(error.stderr || error.message).slice(0, 1000); }
+        }
+        checks.push(check(rel, valid, details));
+    }
+    const db = path.join(ROOT, 'database');
+    try { fs.mkdirSync(db, { recursive: true }); const probe = path.join(db, `.plogme-health-${process.pid}`); fs.writeFileSync(probe, 'ok'); fs.unlinkSync(probe); checks.push(check('database-writable', true, db)); }
+    catch (error) { checks.push(check('database-writable', false, error.message)); }
+    const failed = checks.filter(item => !item.ok);
+    return { ok: failed.length === 0, checkedAt: new Date().toISOString(), checks, failed };
+}
+
+module.exports = { runHealthChecks, CRITICAL_FILES };

--- a/src/Commands/Core/plogme-missions.js
+++ b/src/Commands/Core/plogme-missions.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const ROOT = process.cwd();
+const DATA_DIR = path.join(ROOT, 'database');
+const STORE_FILE = path.join(DATA_DIR, 'plogme_missions.json');
+const SNAPSHOT_DIR = path.join(DATA_DIR, 'plogme_snapshots');
+const MAX_EVENTS = 200;
+const MAX_MISSIONS = 100;
+
+function readStore() {
+    try {
+        if (!fs.existsSync(STORE_FILE)) return { missions: {} };
+        const parsed = JSON.parse(fs.readFileSync(STORE_FILE, 'utf8'));
+        return parsed && typeof parsed === 'object' && parsed.missions ? parsed : { missions: {} };
+    } catch {
+        return { missions: {} };
+    }
+}
+
+function writeStore(store) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+    const temp = `${STORE_FILE}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(temp, JSON.stringify(store, null, 2));
+    fs.renameSync(temp, STORE_FILE);
+}
+
+function now() { return new Date().toISOString(); }
+function missionId() { return `PLOGME-${Date.now().toString(36).toUpperCase()}-${crypto.randomBytes(3).toString('hex').toUpperCase()}`; }
+
+function createMission(input = {}) {
+    const store = readStore();
+    const id = missionId();
+    const mission = {
+        id,
+        chat: String(input.chat || ''),
+        owner: String(input.owner || ''),
+        objective: String(input.objective || 'Unspecified objective').slice(0, 1000),
+        status: 'planning',
+        step: 0,
+        plan: Array.isArray(input.plan) ? input.plan.map(String).slice(0, 50) : [],
+        files: [],
+        tests: [],
+        errors: [],
+        snapshots: [],
+        events: [{ at: now(), type: 'created', message: 'Mission created' }],
+        createdAt: now(),
+        updatedAt: now()
+    };
+    store.missions[id] = mission;
+    const ids = Object.keys(store.missions);
+    while (ids.length > MAX_MISSIONS) delete store.missions[ids.shift()];
+    writeStore(store);
+    return mission;
+}
+
+function getMission(id) { return readStore().missions[String(id)] || null; }
+function listMissions(options = {}) {
+    const missions = Object.values(readStore().missions).sort((a, b) => String(b.updatedAt).localeCompare(String(a.updatedAt)));
+    return options.status ? missions.filter(m => m.status === options.status) : missions;
+}
+
+function updateMission(id, patch = {}) {
+    const store = readStore();
+    const current = store.missions[String(id)];
+    if (!current) return null;
+    const next = { ...current, ...patch, id: current.id, updatedAt: now() };
+    next.events = Array.isArray(patch.events) ? patch.events : current.events;
+    store.missions[current.id] = next;
+    writeStore(store);
+    return next;
+}
+
+function addEvent(id, type, message, extra = {}) {
+    const mission = getMission(id);
+    if (!mission) return null;
+    const events = [...(mission.events || []), { at: now(), type: String(type), message: String(message), ...extra }].slice(-MAX_EVENTS);
+    return updateMission(id, { events });
+}
+
+function setStep(id, step, status, message) {
+    const mission = updateMission(id, { step: Number(step) || 0, ...(status ? { status: String(status) } : {}) });
+    return message ? addEvent(id, 'progress', message, { step: Number(step) || 0 }) : mission;
+}
+
+function recordTest(id, name, passed, details = '') {
+    const mission = getMission(id);
+    if (!mission) return null;
+    const tests = [...(mission.tests || []), { name: String(name), passed: !!passed, details: String(details).slice(0, 2000), at: now() }].slice(-100);
+    return updateMission(id, { tests });
+}
+
+function recordError(id, error) {
+    const mission = getMission(id);
+    if (!mission) return null;
+    const errors = [...(mission.errors || []), { message: String(error?.message || error), at: now() }].slice(-50);
+    return updateMission(id, { errors, status: 'blocked' });
+}
+
+function snapshotFiles(id, files = []) {
+    const mission = getMission(id);
+    if (!mission) return null;
+    fs.mkdirSync(SNAPSHOT_DIR, { recursive: true });
+    const snapshotId = `${id}-${Date.now().toString(36)}`;
+    const dir = path.join(SNAPSHOT_DIR, snapshotId);
+    fs.mkdirSync(dir, { recursive: true });
+    const entries = [];
+    for (const raw of files) {
+        const abs = path.resolve(ROOT, String(raw));
+        if (abs !== ROOT && !abs.startsWith(ROOT + path.sep)) continue;
+        if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) continue;
+        const rel = path.relative(ROOT, abs);
+        const target = path.join(dir, rel);
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.copyFileSync(abs, target);
+        entries.push(rel);
+    }
+    const snapshots = [...(mission.snapshots || []), { id: snapshotId, dir, files: entries, at: now() }].slice(-10);
+    updateMission(id, { snapshots });
+    return { id: snapshotId, dir, files: entries };
+}
+
+function rollbackMission(id, snapshotId) {
+    const mission = getMission(id);
+    if (!mission) return { ok: false, error: 'Mission not found' };
+    const snapshot = (mission.snapshots || []).find(item => item.id === snapshotId) || mission.snapshots?.at(-1);
+    if (!snapshot || !fs.existsSync(snapshot.dir)) return { ok: false, error: 'Snapshot not found' };
+    for (const rel of snapshot.files || []) {
+        const source = path.join(snapshot.dir, rel);
+        const target = path.resolve(ROOT, rel);
+        if (fs.existsSync(source)) {
+            fs.mkdirSync(path.dirname(target), { recursive: true });
+            fs.copyFileSync(source, target);
+        }
+    }
+    addEvent(id, 'rollback', `Restored snapshot ${snapshot.id}`);
+    return { ok: true, snapshot: snapshot.id, files: snapshot.files || [] };
+}
+
+module.exports = {
+    STORE_FILE,
+    SNAPSHOT_DIR,
+    createMission,
+    getMission,
+    listMissions,
+    updateMission,
+    addEvent,
+    setStep,
+    recordTest,
+    recordError,
+    snapshotFiles,
+    rollbackMission
+};

--- a/src/Commands/Core/plogme-project-index.js
+++ b/src/Commands/Core/plogme-project-index.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = process.cwd();
+const COMMAND_ROOT = path.join(ROOT, 'src', 'Commands');
+
+function walk(dir, depth = 0, maxDepth = 6) {
+    if (depth > maxDepth || !fs.existsSync(dir)) return [];
+    const out = [];
+    let entries = [];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return out; }
+    for (const entry of entries) {
+        if (entry.name.startsWith('.') || ['node_modules', 'sessions'].includes(entry.name)) continue;
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...walk(full, depth + 1, maxDepth));
+        else if (/\.(?:js|mjs|cjs|ts)$/i.test(entry.name)) out.push(full);
+    }
+    return out;
+}
+
+function parseCommandSource(source, file) {
+    const name = source.match(/\bname\s*:\s*['"`]([^'"`]+)['"`]/i)?.[1] || path.basename(file).replace(/\.[^.]+$/, '');
+    const aliasMatch = source.match(/\balias\s*:\s*\[([\s\S]*?)\]/i)?.[1] || '';
+    const aliases = [...aliasMatch.matchAll(/['"`]([^'"`]+)['"`]/g)].map(match => match[1]).slice(0, 30);
+    const category = source.match(/\bcategory\s*:\s*['"`]([^'"`]+)['"`]/i)?.[1] || 'Unknown';
+    const imports = [...source.matchAll(/require\(['"`]([^'"`]+)['"`]\)|from\s+['"`]([^'"`]+)['"`]/g)].map(match => match[1] || match[2]).slice(0, 80);
+    let syntax = true;
+    let syntaxError = '';
+    try { execFileSync(process.execPath, ['--check', file], { cwd: ROOT, timeout: 15000, stdio: 'pipe' }); }
+    catch (error) { syntax = false; syntaxError = String(error.stderr || error.message).slice(0, 1000); }
+    return { name, aliases, category, file: path.relative(ROOT, file), imports, syntax, syntaxError };
+}
+
+function buildProjectIndex() {
+    const commands = [];
+    for (const file of walk(COMMAND_ROOT)) {
+        try { commands.push(parseCommandSource(fs.readFileSync(file, 'utf8'), file)); } catch {}
+    }
+    const categories = {};
+    for (const command of commands) (categories[command.category] ||= []).push(command.name);
+    return {
+        generatedAt: new Date().toISOString(),
+        root: ROOT,
+        commandCount: commands.length,
+        syntaxFailures: commands.filter(command => !command.syntax).length,
+        categories,
+        commands
+    };
+}
+
+module.exports = { buildProjectIndex };

--- a/src/Commands/Core/plogme.js
+++ b/src/Commands/Core/plogme.js
@@ -25,7 +25,18 @@
 // which short-circuits the other handlers. @crysnovax—FIX08-07-26
 const fs = require('fs');
 const path = require('path');
-const axios = require('axios');
+const axios = {
+    get: async (url, options = {}) => {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), options.timeout || 15000);
+        try {
+            const response = await fetch(url, { headers: options.headers || {}, signal: controller.signal });
+            return { data: await response.text(), status: response.status };
+        } finally {
+            clearTimeout(timer);
+        }
+    }
+};
 const { execSync } = require('child_process');
 const { getVar } = require('../../Plugin/configManager');
 
@@ -144,6 +155,70 @@ function fuzzyFindFile(raw) {
         if (hit) return { abs: hit, display: path.relative(ROOT, hit) };
     }
     return null;
+}
+
+// Bounded workspace helpers used by PLOGME’s structured tools. Every file search stays
+// inside the project and skips secrets, dependencies, sessions, and git metadata.
+function walkWorkspace(start = ROOT, maxDepth = 4) {
+    const found = [];
+    const walk = (dir, depth) => {
+        if (depth > maxDepth) return;
+        let entries = [];
+        try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+        for (const entry of entries) {
+            if (entry.name.startsWith('.') || ['node_modules', '.git', 'sessions'].includes(entry.name)) continue;
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) walk(full, depth + 1);
+            else found.push(full);
+        }
+    };
+    walk(path.resolve(start), 0);
+    return found;
+}
+function searchWorkspace(query, options = {}) {
+    const needle = String(query || '').trim();
+    if (!needle) return [];
+    const paths = walkWorkspace(ROOT, options.maxDepth || 4);
+    const codeOnly = options.codeOnly === true;
+    const regex = options.regex ? new RegExp(needle, options.flags || 'i') : null;
+    const results = [];
+    for (const file of paths) {
+        if (codeOnly && !/\.(?:js|mjs|cjs|ts|tsx|jsx|py|json|md|yml|yaml)$/i.test(file)) continue;
+        let stat;
+        try { stat = fs.statSync(file); } catch { continue; }
+        if (stat.size > 1024 * 1024) continue;
+        let content;
+        try { content = fs.readFileSync(file, 'utf8'); } catch { continue; }
+        const lines = content.split(/\r?\n/);
+        lines.forEach((line, index) => {
+            if ((regex ? regex.test(line) : line.toLowerCase().includes(needle.toLowerCase()))) {
+                results.push({ file: path.relative(ROOT, file), line: index + 1, text: line.trim().slice(0, 240) });
+            }
+        });
+        if (results.length >= (options.limit || 40)) break;
+    }
+    return results;
+}
+function environmentSnapshot() {
+    const packageJson = loadJson(path.join(ROOT, 'package.json'), {});
+    return {
+        cwd: ROOT,
+        platform: process.platform,
+        node: process.version,
+        package: packageJson.name || 'unknown',
+        packageVersion: packageJson.version || 'unknown',
+        uptimeSeconds: Math.round(process.uptime()),
+        memoryMb: Math.round(process.memoryUsage().rss / 1024 / 1024),
+        commandsDir: fs.existsSync(USER_CMD_DIR),
+        outputDir: fs.existsSync(OUT_DIR),
+        files: walkWorkspace(ROOT, 2).length
+    };
+}
+async function reportProgress(opts, message) {
+    try {
+        if (typeof opts?.progress === 'function') return await opts.progress(String(message));
+        if (typeof opts?.reply === 'function') return await opts.reply(`_*🛠️ PLOGME:*_ ${String(message)}`);
+    } catch {}
 }
 
 // Render markdown/text to a PDF buffer with pdfkit (already a dependency —
@@ -973,7 +1048,7 @@ const KNOWN_ACTIONS = new Set([
     'set_pp', 'group_pp', 'group_name', 'kick', 'promote', 'demote',
     'mute_user', 'unmute_user', 'mutesch', 'antis', 'plogme_mode',
     // FIX12-08-26: file delivery — send files, generate PDFs, zip archives
-    'send_file', 'make_pdf', 'zip',
+    'send_file', 'make_pdf', 'zip', 'search_file', 'search_code', 'search_web', 'environment', 'create_tool',
 ]);
 
 // Strip markdown fences / extra text and pull out the first JSON object.
@@ -1036,13 +1111,17 @@ function buildClassifierPrompt(userText) {
         `- "turn on/off all the antis / protections / security" -> {"action":"antis","state":"on"}\n` +
         `- "set plogme mode to all/tag" -> {"action":"plogme_mode","mode":"all"}\n` +
         `- "send/attach/share the file X" / "send me the pdf" / "send the file" -> {"action":"send_file","path":"<path>"}\n` +
+        `- "find/search for X in my files/code" -> {"action":"search_file"|"search_code","query":"X"}\n` +
+        `- "search the web for X" -> {"action":"search_web","query":"X"}\n` +
+        `- "what is the bot environment/status" -> {"action":"environment"}\n` +
+        `- "create a tool for X" -> {"action":"create_tool","name":"<name>","content":"<full JS module>"}\n` +
         `- "make/generate/create a PDF from X" / "convert X to pdf" / "write a pdf about/on X" -> {"action":"make_pdf","path":"<path or topic>"} (or "content":"<text>" for pasted text)\n` +
         `- "zip/compress these files" -> {"action":"zip","files":["<path1>","<path2>"]}\n` +
         `(for user actions the target comes from the @mention or the quoted message, so "mentioned" is the right value)\n\n` +
         `Possible actions: run_command, create_file, edit_file, delete_file, toggle_command, ` +
         `list_commands, reload, restart, status, memory, clear_memory, remember, forget, ` +
         `test, fix_code, train, personality, dev, set_pp, group_name, group_pp, kick, promote, ` +
-        `demote, mute_user, unmute_user, mutesch, antis, plogme_mode, send_file, make_pdf, zip, chat.\n\n` +
+        `demote, mute_user, unmute_user, mutesch, antis, plogme_mode, send_file, make_pdf, zip, search_file, search_code, search_web, environment, create_tool, chat.\n\n` +
         `JSON shapes:\n` +
         `- {"action":"run_command","command":"<name>","args":"<optional>"}\n` +
         `- {"action":"create_file","path":"src/Commands/User/name.js","content":"<FULL file content>"}\n` +
@@ -1061,10 +1140,13 @@ function buildClassifierPrompt(userText) {
         `- {"action":"mutesch","start":"5pm","end":"10am","repeat":"daily|once"}\n` +
         `- {"action":"antis","state":"on|off"} {"action":"plogme_mode","mode":"all|tag"}\n` +
         `- {"action":"send_file","path":"<path>"} {"action":"make_pdf","path":"<path>"|"content":"<text>"} {"action":"zip","files":["<path1>"]}\n` +
+        `- {"action":"search_file"|"search_code","query":"<text>"} {"action":"search_web","query":"<text>"}\n` +
+        `- {"action":"environment"} {"action":"create_tool","name":"<name>","content":"<full JS module>"}\n` +
         `- {"action":"chat","reply":"<your short reply>"}\n\n` +
         `Available commands (ONLY use these exact names for run_command):\n` +
         (realCommands.length ? realCommands.slice(0, 160).join(', ') : '(command list unavailable)') +
         refNote +
+        `\n\nLIVE ENVIRONMENT SNAPSHOT (use this to reason about paths, runtime, and available workspace): ${JSON.stringify(environmentSnapshot())}` +
         `\n\nOwner message: "${String(userText || '').slice(0, 2000)}"`;
 }
 
@@ -1085,7 +1167,11 @@ async function classifyIntent(userText) {
 // with the message (including as a chat reply).
 async function executeIntent(sock, m, opts, intent) {
     try {
+        opts = { ...opts, sendMessage: opts?.sendMessage || (typeof sock?.sendMessage === 'function' ? sock.sendMessage.bind(sock) : null) };
         const action = intent.action;
+        if (['create_file', 'edit_file', 'create_tool', 'send_file', 'search_file', 'search_code', 'search_web', 'make_pdf', 'zip'].includes(action)) {
+            await reportProgress(opts, `starting ${action.replace(/_/g, ' ')}…`);
+        }
 
         switch (action) {
             case 'run_command': {
@@ -1433,6 +1519,61 @@ async function executeIntent(sock, m, opts, intent) {
                 return { handled: true };
             }
 
+            case 'search_file':
+            case 'search_code': {
+                const query = String(intent.query || intent.text || intent.pattern || '').trim();
+                if (!query) { await opts.reply('_✘ Tell me what text or pattern to search for_'); return { handled: true }; }
+                const results = searchWorkspace(query, { codeOnly: action === 'search_code', regex: intent.regex === true, limit: 40 });
+                const rendered = results.map(r => '• `' + r.file + ':' + r.line + '` ' + r.text).join('\n');
+                await opts.reply(results.length
+                    ? `_*🔎 ${action === 'search_code' ? 'Code' : 'File'} search results for* _${query.slice(0, 80)}_\n${rendered}`
+                    : `_*🔎 No matches found for* _${query.slice(0, 80)}_`);
+                logOp(action, `${query.slice(0, 100)} (${results.length} matches)`);
+                return { handled: true };
+            }
+
+            case 'search_web': {
+                const query = String(intent.query || intent.text || '').trim();
+                if (!query) { await opts.reply('_✘ Tell me what to search for on the web_'); return { handled: true }; }
+                try {
+                    const url = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
+                    const response = await axios.get(url, { timeout: 15000, headers: { 'user-agent': 'CODY-PLOGME/1.0' } });
+                    const html = String(response.data || '');
+                    const matches = [...html.matchAll(/class="result__a"[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi)].slice(0, 5);
+                    const clean = value => String(value || '').replace(/<[^>]+>/g, '').replace(/&amp;/g, '&').replace(/&#x27;/g, "'").trim();
+                    const lines = matches.map((match, i) => `${i + 1}. ${clean(match[2])}\n${match[1]}`);
+                    await opts.reply(lines.length ? `_*🌐 Web results for* _\`${query.slice(0, 80)}\`_\n${lines.join('\n')}` : '_*🌐 Search completed, but no results were returned.*_');
+                    logOp('search_web', `${query.slice(0, 100)} (${lines.length} results)`);
+                } catch (err) {
+                    await opts.reply(`_✘ Web search failed:_ ${err.message}`);
+                }
+                return { handled: true };
+            }
+
+            case 'environment': {
+                const env = environmentSnapshot();
+                await opts.reply(`_*🧭 PLOGME ENVIRONMENT*_\n\n` +
+                    `• cwd: \`${env.cwd}\`\n• platform: ${env.platform}\n• Node: ${env.node}\n` +
+                    `• package: ${env.package}@${env.packageVersion}\n• uptime: ${env.uptimeSeconds}s\n` +
+                    `• memory: ${env.memoryMb} MB\n• workspace files: ${env.files}\n` +
+                    `• commands dir: ${env.commandsDir ? 'ready' : 'missing'}\n• output dir: ${env.outputDir ? 'ready' : 'will be created'}`);
+                return { handled: true };
+            }
+
+            case 'create_tool': {
+                const toolName = sanitizeCommandName(intent.name || intent.tool || 'plogme-tool');
+                const content = String(intent.content || intent.code || '').trim();
+                if (!toolName || !content) { await opts.reply('_✘ A tool name and complete JavaScript module are required_'); return { handled: true }; }
+                const target = resolveWritePath(path.join('src', 'Commands', 'User', 'Tools', `${toolName}.js`));
+                if (!target) { await opts.reply('_✘ Invalid tool path_'); return { handled: true }; }
+                const res = await writeFileWithAgentFix(target.abs, content, opts);
+                if (!res.ok) { await opts.reply('_*✘ Tool syntax failed:*_\n' + String(res.error || '').slice(0, 1400)); return { handled: true }; }
+                logOp('create_tool', target.display);
+                await opts.reply('_*✅ Tool created and syntax-checked:*_ ' + target.display);
+                try { await opts.sendMessage(m.chat, { document: fs.readFileSync(target.abs), mimetype: 'application/javascript', fileName: `${toolName}.js` }, { quoted: m }); } catch (err) { await opts.reply(`_⚠️ Tool created, but attachment failed:_ ${err.message}`); }
+                return { handled: true };
+            }
+
             case 'send_file': {
                 // "send as a js file" (no name) → newest command file just created
                 // (@crysnovax—FIX14-08-26)
@@ -1746,6 +1887,10 @@ module.exports = {
     resolveWritePath,
     ensureCommandModule,
     writeFileWithAgentFix,
+    walkWorkspace,
+    searchWorkspace,
+    environmentSnapshot,
+    reportProgress,
     logOp,
     getOps,
 };

--- a/src/Commands/Core/plogme.js
+++ b/src/Commands/Core/plogme.js
@@ -39,6 +39,10 @@ const axios = {
 };
 const { execSync } = require('child_process');
 const { getVar } = require('../../Plugin/configManager');
+const missions = require('./plogme-missions');
+const dependencies = require('./plogme-dependencies');
+const { runHealthChecks } = require('./plogme-health');
+const { buildProjectIndex } = require('./plogme-project-index');
 
 const DATA_DIR = path.join(process.cwd(), 'database');
 const USER_CMD_DIR = path.join(__dirname, '../Commands/User');
@@ -199,6 +203,39 @@ function searchWorkspace(query, options = {}) {
     }
     return results;
 }
+async function researchWeb(query, limit = 3) {
+    const q = String(query || '').trim();
+    if (!q) return { query: q, sources: [] };
+    const response = await fetch(`https://html.duckduckgo.com/html/?q=${encodeURIComponent(q)}`, { headers: { 'user-agent': 'CODY-PLOGME/1.0' } });
+    const html = await response.text();
+    const links = [...html.matchAll(/class="result__a"[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi)].slice(0, limit);
+    const clean = value => String(value || '').replace(/<[^>]+>/g, '').replace(/&amp;/g, '&').replace(/&#x27;/g, "'").replace(/&quot;/g, '"').trim();
+    const sources = [];
+    for (const match of links) {
+        const url = match[1];
+        try {
+            const page = await fetch(url, { headers: { 'user-agent': 'CODY-PLOGME/1.0' }, signal: AbortSignal.timeout(12000) });
+            const body = clean((await page.text()).replace(/<script[\s\S]*?<\/script>/gi, ' ').replace(/<style[\s\S]*?<\/style>/gi, ' ')).replace(/\s+/g, ' ').slice(0, 5000);
+            sources.push({ title: clean(match[2]), url, excerpt: body });
+        } catch { sources.push({ title: clean(match[2]), url, excerpt: '' }); }
+    }
+    return { query: q, sources };
+}
+async function sendMissionControls(sock, m, mission) {
+    if (typeof sock?.sendRichButtonGrid !== 'function') return null;
+    try {
+        return await sock.sendRichButtonGrid(m.chat, {
+            text: `MISSION ${mission.id}`,
+            footer: mission.objective.slice(0, 120),
+            cards: [{ title: 'Mission Control', buttons: [
+                { id: `mission_status:${mission.id}`, text: 'View Status' },
+                { id: `mission_pause:${mission.id}`, text: 'Pause' },
+                { id: `mission_resume:${mission.id}`, text: 'Resume' },
+                { id: `mission_rollback:${mission.id}`, text: 'Rollback' }
+            ] }]
+        });
+    } catch { return null; }
+}
 function environmentSnapshot() {
     const packageJson = loadJson(path.join(ROOT, 'package.json'), {});
     return {
@@ -216,6 +253,7 @@ function environmentSnapshot() {
 }
 async function reportProgress(opts, message) {
     try {
+        if (opts?.missionId) missions.addEvent(opts.missionId, 'progress', message);
         if (typeof opts?.progress === 'function') return await opts.progress(String(message));
         if (typeof opts?.reply === 'function') return await opts.reply(`_*🛠️ PLOGME:*_ ${String(message)}`);
     } catch {}
@@ -1049,6 +1087,8 @@ const KNOWN_ACTIONS = new Set([
     'mute_user', 'unmute_user', 'mutesch', 'antis', 'plogme_mode',
     // FIX12-08-26: file delivery — send files, generate PDFs, zip archives
     'send_file', 'make_pdf', 'zip', 'search_file', 'search_code', 'search_web', 'environment', 'create_tool',
+    'mission_create', 'mission_list', 'mission_status', 'mission_pause', 'mission_resume', 'mission_rollback',
+    'dependency_status', 'suggest_dependency', 'install_dependency', 'project_index', 'health', 'research_web', 'inspect_media',
 ]);
 
 // Strip markdown fences / extra text and pull out the first JSON object.
@@ -1115,13 +1155,20 @@ function buildClassifierPrompt(userText) {
         `- "search the web for X" -> {"action":"search_web","query":"X"}\n` +
         `- "what is the bot environment/status" -> {"action":"environment"}\n` +
         `- "create a tool for X" -> {"action":"create_tool","name":"<name>","content":"<full JS module>"}\n` +
+        `- "plan/start/track this task" -> {"action":"mission_create","objective":"<goal>","plan":["<step>"]}\n` +
+        `- "show/list/resume/pause/rollback mission" -> use mission_list, mission_status, mission_resume, mission_pause, or mission_rollback\n` +
+        `- "suggest/check/install dependency X" -> use suggest_dependency, dependency_status, or install_dependency\n` +
+        `- "index the project / inspect project structure" -> {"action":"project_index"}\n` +
+        `- "run health check / diagnose bot" -> {"action":"health"}\n` +
+        `- "research X on the web" -> {"action":"research_web","query":"X"}\n` +
+        `- "inspect/analyze this image, video, audio, or document" -> {"action":"inspect_media"}\n` +
         `- "make/generate/create a PDF from X" / "convert X to pdf" / "write a pdf about/on X" -> {"action":"make_pdf","path":"<path or topic>"} (or "content":"<text>" for pasted text)\n` +
         `- "zip/compress these files" -> {"action":"zip","files":["<path1>","<path2>"]}\n` +
         `(for user actions the target comes from the @mention or the quoted message, so "mentioned" is the right value)\n\n` +
         `Possible actions: run_command, create_file, edit_file, delete_file, toggle_command, ` +
         `list_commands, reload, restart, status, memory, clear_memory, remember, forget, ` +
         `test, fix_code, train, personality, dev, set_pp, group_name, group_pp, kick, promote, ` +
-        `demote, mute_user, unmute_user, mutesch, antis, plogme_mode, send_file, make_pdf, zip, search_file, search_code, search_web, environment, create_tool, chat.\n\n` +
+        `demote, mute_user, unmute_user, mutesch, antis, plogme_mode, send_file, make_pdf, zip, search_file, search_code, search_web, environment, create_tool, mission_create, mission_list, mission_status, mission_pause, mission_resume, mission_rollback, dependency_status, suggest_dependency, install_dependency, project_index, health, research_web, inspect_media, chat.\n\n` +
         `JSON shapes:\n` +
         `- {"action":"run_command","command":"<name>","args":"<optional>"}\n` +
         `- {"action":"create_file","path":"src/Commands/User/name.js","content":"<FULL file content>"}\n` +
@@ -1142,6 +1189,10 @@ function buildClassifierPrompt(userText) {
         `- {"action":"send_file","path":"<path>"} {"action":"make_pdf","path":"<path>"|"content":"<text>"} {"action":"zip","files":["<path1>"]}\n` +
         `- {"action":"search_file"|"search_code","query":"<text>"} {"action":"search_web","query":"<text>"}\n` +
         `- {"action":"environment"} {"action":"create_tool","name":"<name>","content":"<full JS module>"}\n` +
+        `- {"action":"mission_create","objective":"<goal>","plan":["<step>"]} {"action":"mission_list"} {"action":"mission_status","id":"<id>"}\n` +
+        `- {"action":"mission_pause|mission_resume|mission_rollback","id":"<id>"}\n` +
+        `- {"action":"dependency_status|suggest_dependency|install_dependency","package":"<name>"}\n` +
+        `- {"action":"project_index"} {"action":"health"} {"action":"research_web","query":"<topic>"} {"action":"inspect_media"}\n` +
         `- {"action":"chat","reply":"<your short reply>"}\n\n` +
         `Available commands (ONLY use these exact names for run_command):\n` +
         (realCommands.length ? realCommands.slice(0, 160).join(', ') : '(command list unavailable)') +
@@ -1169,7 +1220,13 @@ async function executeIntent(sock, m, opts, intent) {
     try {
         opts = { ...opts, sendMessage: opts?.sendMessage || (typeof sock?.sendMessage === 'function' ? sock.sendMessage.bind(sock) : null) };
         const action = intent.action;
-        if (['create_file', 'edit_file', 'create_tool', 'send_file', 'search_file', 'search_code', 'search_web', 'make_pdf', 'zip'].includes(action)) {
+        const missionActions = new Set(['create_file', 'edit_file', 'create_tool', 'send_file', 'make_pdf', 'zip', 'install_dependency', 'project_index', 'health', 'research_web', 'inspect_media']);
+        if (missionActions.has(action) && !opts.missionId) {
+            const mission = missions.createMission({ chat: m.chat, owner: m.sender || '', objective: String(intent.objective || intent.query || intent.path || action).slice(0, 1000), plan: ['inspect workspace and dependencies', `execute ${action}`, 'verify result and report'] });
+            opts.missionId = mission.id;
+            missions.updateMission(mission.id, { status: 'running' });
+        }
+        if (['create_file', 'edit_file', 'create_tool', 'send_file', 'search_file', 'search_code', 'search_web', 'make_pdf', 'zip', 'mission_create', 'mission_rollback', 'install_dependency', 'project_index', 'health', 'research_web', 'inspect_media'].includes(action)) {
             await reportProgress(opts, `starting ${action.replace(/_/g, ' ')}…`);
         }
 
@@ -1193,6 +1250,7 @@ async function executeIntent(sock, m, opts, intent) {
                 if (!content.trim()) { await opts.reply('_✘ No file content provided_'); return { handled: true }; }
                 if (name) content = ensureCommandModule(name, content);
                 const res = await writeFileWithAgentFix(abs, content, opts);
+                if (opts.missionId) { missions.addEvent(opts.missionId, res.ok ? 'verified' : 'failed', res.ok ? `Created and syntax-checked ${display}` : `Syntax failure in ${display}`); missions.updateMission(opts.missionId, { status: res.ok ? 'completed' : 'blocked', files: [display] }); }
                 logOp('create', `${display}${name ? ` (command .${name})` : ''}`);
                 if (res.ok) {
                     if (display.includes('Commands')) { try { require('../../Plugin/crysLoadCmd').loadCommands(); } catch {} }
@@ -1233,7 +1291,9 @@ async function executeIntent(sock, m, opts, intent) {
                     next = String(intent.content || '');
                 }
                 if (!next.trim()) { await opts.reply('_✘ No replacement content provided_'); return { handled: true }; }
+                if (opts.missionId) missions.snapshotFiles(opts.missionId, [display]);
                 const res = await writeFileWithAgentFix(abs, next, opts);
+                if (opts.missionId) { missions.addEvent(opts.missionId, res.ok ? 'verified' : 'failed', res.ok ? `Edited and syntax-checked ${display}` : `Syntax failure in ${display}`); missions.updateMission(opts.missionId, { status: res.ok ? 'completed' : 'blocked', files: [display] }); }
                 logOp('edit', display);
                 if (res.ok) {
                     if (display.includes('Commands')) { try { require('../../Plugin/crysLoadCmd').loadCommands(); } catch {} }
@@ -1560,6 +1620,132 @@ async function executeIntent(sock, m, opts, intent) {
                 return { handled: true };
             }
 
+            case 'mission_create': {
+                const objective = String(intent.objective || intent.goal || intent.text || '').trim();
+                if (!objective) { await opts.reply('_✘ Tell me what the mission should accomplish_'); return { handled: true }; }
+                const plan = Array.isArray(intent.plan) ? intent.plan : String(intent.plan || '').split(/\s*[,;]\s*/).filter(Boolean);
+                const mission = missions.createMission({ chat: m.chat, owner: m.sender || '', objective, plan });
+                if (intent.files) {
+                    const files = Array.isArray(intent.files) ? intent.files : [intent.files];
+                    missions.snapshotFiles(mission.id, files);
+                }
+                await opts.reply(`_*🧭 Mission created:*_ ${mission.id}\n\n*Objective:* ${mission.objective}\n` + (mission.plan.length ? mission.plan.map((step, i) => `${i + 1}. ${step}`).join('\n') : '_No plan supplied; I will inspect and plan the next steps._'));
+                await sendMissionControls(sock, m, mission);
+                return { handled: true };
+            }
+
+            case 'mission_list': {
+                const items = missions.listMissions({ status: intent.status });
+                await opts.reply(items.length
+                    ? `_*🧭 Recent PLOGME missions*_\n` + items.slice(0, 12).map(item => `• ${item.id} — ${item.status} — ${item.objective.slice(0, 90)}`).join('\n')
+                    : '_No PLOGME missions have been recorded yet._');
+                return { handled: true };
+            }
+
+            case 'mission_status': {
+                const item = missions.getMission(intent.id || intent.mission || intent.missionId) || missions.listMissions()[0];
+                if (!item) { await opts.reply('_✘ Mission not found_'); return { handled: true }; }
+                const lastEvents = (item.events || []).slice(-8).map(event => `• ${event.at.slice(11, 19)} ${event.message}`).join('\n');
+                await opts.reply(`_*🧭 ${item.id}*_\n*Status:* ${item.status}\n*Step:* ${item.step}/${item.plan.length || '?'}\n*Objective:* ${item.objective}\n\n${lastEvents || '_No events yet._'}`);
+                return { handled: true };
+            }
+
+            case 'mission_pause':
+            case 'mission_resume': {
+                const item = missions.getMission(intent.id || intent.mission || intent.missionId);
+                if (!item) { await opts.reply('_✘ Mission not found_'); return { handled: true }; }
+                const nextStatus = action === 'mission_pause' ? 'paused' : 'running';
+                missions.updateMission(item.id, { status: nextStatus });
+                missions.addEvent(item.id, nextStatus, `Mission ${nextStatus}`);
+                await opts.reply(`_*${nextStatus === 'paused' ? '⏸️' : '▶️'} ${item.id}: ${nextStatus.toUpperCase()}*_`);
+                return { handled: true };
+            }
+
+            case 'mission_rollback': {
+                const item = missions.getMission(intent.id || intent.mission || intent.missionId);
+                if (!item) { await opts.reply('_✘ Mission not found_'); return { handled: true }; }
+                const result = missions.rollbackMission(item.id, intent.snapshot);
+                await opts.reply(result.ok ? `_*↶ Rollback complete:*_ ${item.id}\n${result.files.join('\n') || 'No files restored'}` : `_✘ Rollback failed:_ ${result.error}`);
+                return { handled: true };
+            }
+
+            case 'dependency_status': {
+                const raw = intent.package || intent.name || intent.spec;
+                const status = dependencies.localStatus(raw);
+                if (!status.ok) { await opts.reply(`_✘ ${status.error}_`); return { handled: true }; }
+                await opts.reply(`_*📦 Dependency status*_\n• Package: ${status.name}\n• Requested: ${status.spec}\n• Declared: ${status.declared || 'not declared'}\n• Installed: ${status.installed || 'missing'}\n• State: ${status.missing ? 'MISSING' : 'READY'}`);
+                return { handled: true };
+            }
+
+            case 'suggest_dependency': {
+                const raw = intent.package || intent.name || intent.spec;
+                const info = await dependencies.registryInfo(raw);
+                if (!info.ok) { await opts.reply(`_✘ Dependency lookup failed:_ ${info.error}`); return { handled: true }; }
+                await opts.reply(`_*📦 Dependency suggestion*_\n• Package: ${info.name}\n• Latest: ${info.latest || 'unknown'}\n• Description: ${info.description || 'not provided'}\n• Status: ${info.deprecated ? `DEPRECATED — ${info.deprecated}` : 'not marked deprecated'}\n\nUse “install ${info.name}” when you want me to add it explicitly.`);
+                return { handled: true };
+            }
+
+            case 'install_dependency': {
+                const raw = intent.package || intent.name || intent.spec;
+                const spec = dependencies.packageSpec(raw);
+                if (!spec) { await opts.reply('_✘ Invalid package name or version spec_'); return { handled: true }; }
+                await reportProgress(opts, `checking ${spec} in the npm registry…`);
+                const info = await dependencies.registryInfo(spec);
+                if (!info.ok) { await opts.reply(`_✘ I could not verify ${spec}: ${info.error}_`); return { handled: true }; }
+                if (info.deprecated) { await opts.reply(`_⚠️ ${spec} is deprecated: ${info.deprecated}. I will not install it automatically.`); return { handled: true }; }
+                await reportProgress(opts, `installing ${spec}; npm will update package.json and package-lock.json…`);
+                const result = dependencies.install(spec);
+                if (opts.missionId) { missions.addEvent(opts.missionId, result.ok ? 'verified' : 'failed', result.ok ? `Installed dependency ${spec}` : `Dependency installation failed for ${spec}`); missions.updateMission(opts.missionId, { status: result.ok ? 'completed' : 'blocked' }); }
+                if (!result.ok) { await opts.reply(`_✘ Dependency installation failed for ${spec}_\n\n${result.output.slice(-3000)}`); return { handled: true }; }
+                await opts.reply(`_*✅ Dependency installed:*_ ${spec}\n\n${result.output.slice(-1200)}`);
+                return { handled: true };
+            }
+
+            case 'project_index': {
+                await reportProgress(opts, 'indexing commands, aliases, imports, and syntax state…');
+                const index = buildProjectIndex();
+                const indexFile = path.join(DATA_DIR, 'plogme_project_index.json');
+                if (opts.missionId) { missions.addEvent(opts.missionId, 'verified', `Indexed ${index.commandCount} commands`); missions.updateMission(opts.missionId, { status: 'completed' }); }
+                saveJson(indexFile, index);
+                const failures = index.commands.filter(command => !command.syntax).slice(0, 8);
+                await opts.reply(`_*🗂️ Project index ready*_\n• Commands discovered: ${index.commandCount}\n• Categories: ${Object.keys(index.categories).length}\n• Syntax failures: ${index.syntaxFailures}\n• Saved: ${path.relative(ROOT, indexFile)}` + (failures.length ? `\n\n*Failures:*\n${failures.map(item => `• ${item.file}: ${item.syntaxError.slice(0, 160)}`).join('\n')}` : ''));
+                return { handled: true };
+            }
+
+            case 'health': {
+                await reportProgress(opts, 'running runtime, database, dependency, and critical-file health checks…');
+                const report = runHealthChecks();
+                if (opts.missionId) { missions.addEvent(opts.missionId, report.ok ? 'verified' : 'failed', report.ok ? 'Health checks passed' : `${report.failed.length} health checks failed`); missions.updateMission(opts.missionId, { status: report.ok ? 'completed' : 'blocked' }); }
+                await opts.reply(`_*🩺 CODY health: ${report.ok ? 'HEALTHY' : 'ATTENTION REQUIRED'}*_\n` + report.checks.map(item => `${item.ok ? '✅' : '❌'} ${item.name}: ${item.details}`).join('\n'));
+                return { handled: true };
+            }
+
+            case 'research_web': {
+                const query = String(intent.query || intent.topic || '').trim();
+                if (!query) { await opts.reply('_✘ Tell me what to research_'); return { handled: true }; }
+                await reportProgress(opts, `researching ${query.slice(0, 100)} and extracting source passages…`);
+                try {
+                    const research = await researchWeb(query, 3);
+                    if (!research.sources.length) { await opts.reply('_*🌐 Research completed, but no sources were found.*_'); return { handled: true }; }
+                    const sourceText = research.sources.map((source, i) => `SOURCE ${i + 1}: ${source.title}\nURL: ${source.url}\nEXCERPT: ${source.excerpt.slice(0, 1800)}`).join('\n\n');
+                    const synthesis = await askAI(`Research question: ${query}\n\nUse the sources below. Return a concise answer, distinguish facts from uncertainty, and cite sources as [1], [2], [3].\n\n${sourceText}`);
+                    await opts.reply(`_*🌐 Research: ${query}*_\n\n${synthesis || research.sources.map((source, i) => `[${i + 1}] ${source.title}\n${source.url}`).join('\n\n')}\n\n*Sources:*\n${research.sources.map((source, i) => `[${i + 1}] ${source.url}`).join('\n')}`);
+                    if (opts.missionId) { missions.addEvent(opts.missionId, 'verified', `Research completed with ${research.sources.length} sources`); missions.updateMission(opts.missionId, { status: 'completed' }); }
+                } catch (error) {
+                    if (opts.missionId) missions.recordError(opts.missionId, error);
+                    await opts.reply(`_✘ Research failed:_ ${error.message}`);
+                }
+                return { handled: true };
+            }
+
+            case 'inspect_media': {
+                const inspector = opts.inspectMedia || sock.inspectMedia || sock.describeMedia;
+                if (typeof inspector !== 'function') { await opts.reply('_✘ Multimodal inspection is not connected in this runtime yet. The tool contract is ready; provide an image/video/audio/document inspector callback._'); return { handled: true }; }
+                const result = await inspector(m.quoted || m, { prompt: intent.prompt || intent.query || 'Inspect this media and report actionable details.' });
+                await opts.reply(String(result || '_No media observations returned._'));
+                return { handled: true };
+            }
+
             case 'create_tool': {
                 const toolName = sanitizeCommandName(intent.name || intent.tool || 'plogme-tool');
                 const content = String(intent.content || intent.code || '').trim();
@@ -1567,6 +1753,7 @@ async function executeIntent(sock, m, opts, intent) {
                 const target = resolveWritePath(path.join('src', 'Commands', 'User', 'Tools', `${toolName}.js`));
                 if (!target) { await opts.reply('_✘ Invalid tool path_'); return { handled: true }; }
                 const res = await writeFileWithAgentFix(target.abs, content, opts);
+                if (opts.missionId) { missions.addEvent(opts.missionId, res.ok ? 'verified' : 'failed', res.ok ? `Created and syntax-checked tool ${target.display}` : `Syntax failure in tool ${target.display}`); missions.updateMission(opts.missionId, { status: res.ok ? 'completed' : 'blocked', files: [target.display] }); }
                 if (!res.ok) { await opts.reply('_*✘ Tool syntax failed:*_\n' + String(res.error || '').slice(0, 1400)); return { handled: true }; }
                 logOp('create_tool', target.display);
                 await opts.reply('_*✅ Tool created and syntax-checked:*_ ' + target.display);
@@ -1755,8 +1942,12 @@ async function execute(sock, m, opts) {
         // command too — no more strict phrasing. @crysnovax—FIX08-07-26
         if (privileged) {
             const body = isCommand ? text.slice(prefix.length).trim() : text;
-            const isPlogmeInvocation = /^(plogme|plg|plog)(\s|$)/i.test(body);
-
+                        const isPlogmeInvocation = /^(plogme|plg|plog)(\s|$)/i.test(body);
+            const missionButton = body.match(/^(mission_status|mission_pause|mission_resume|mission_rollback):([A-Z0-9-]+)$/i);
+            if (missionButton) {
+                await executeIntent(sock, m, opts, { action: missionButton[1].toLowerCase(), id: missionButton[2] });
+                return true;
+            }
             // A prefixed ".plogme <sub>" (e.g. "/plogme off") is OWNED by the
             // router command src/Commands/AI/plogme.js, which already replied
             // ("✖ DISABLED"). Running the control intents again made every

--- a/src/Commands/Group/⤷.js
+++ b/src/Commands/Group/⤷.js
@@ -17,14 +17,35 @@ const RESTRICTED_GROUPS = new Set([
 
 const normalizeJid = (jid = '') => String(jid || '').replace(/:\d+@/, '@');
 const STATUS_COLORS = ['#FF6B6B', '#4D96FF', '#6BCB77', '#FFD93D', '#845EC2', '#00C9A7'];
+const NAMED_STATUS_COLORS = { red: '#FF6B6B', blue: '#4D96FF', green: '#6BCB77', yellow: '#FFD93D', purple: '#845EC2', violet: '#845EC2', teal: '#00C9A7', cyan: '#00C9A7', orange: '#FF9671', pink: '#FF6F91', white: '#FFFFFF', black: '#000000' };
 let statusColorIndex = 0;
 const nextStatusColor = () => STATUS_COLORS[statusColorIndex++ % STATUS_COLORS.length];
+const normalizeBackgroundColor = value => {
+    const raw = String(value || '').trim().toLowerCase();
+    if (!raw) return undefined;
+    if (NAMED_STATUS_COLORS[raw]) return NAMED_STATUS_COLORS[raw];
+    if (/^#[0-9a-f]{6}$/i.test(raw)) return raw.toUpperCase();
+    if (/^[0-9a-f]{6}$/i.test(raw)) return `#${raw.toUpperCase()}`;
+    return undefined;
+};
 const parseStatusOptions = (text = '', args = []) => {
-    const tokens = Array.isArray(args) && args.length ? args : String(text).split(/\s+/).filter(Boolean);
-    const backgroundToken = tokens.find(token => /^--bg=/i.test(token));
-    const backgroundColor = backgroundToken ? backgroundToken.slice(backgroundToken.indexOf('=') + 1) : undefined;
-    const cleanTokens = tokens.filter(token => !/^--bg=/i.test(token));
-    return { backgroundColor, cleanText: cleanTokens.join(' ').trim() };
+    let source = Array.isArray(args) && args.length ? args.join(' ') : String(text);
+    let caption;
+    const bgMatch = source.match(/(?:^|\s)--bg=([^\s]+)/i);
+    const backgroundColor = normalizeBackgroundColor(bgMatch?.[1]);
+    source = source.replace(/(?:^|\s)--bg=[^\s]+/gi, ' ').trim();
+    const cpMatch = source.match(/(?:^|\s)--cp=(.+)$/i);
+    if (cpMatch) { caption = cpMatch[1].trim().replace(/^['\"]|['\"]$/g, ''); source = source.slice(0, cpMatch.index).trim(); }
+    const copyCaption = /(?:^|\s)(?:-cp|--copy-caption)(?=\s|$)/i.test(source);
+    source = source.replace(/(?:^|\s)(?:-cp|--copy-caption)(?=\s|$)/gi, ' ').trim();
+    const cleanTokens = source.split(/\s+/).filter(Boolean).filter(token => !/^id.+@g\.us$/i.test(token));
+    return { backgroundColor, copyCaption, caption, cleanText: cleanTokens.join(' ').trim() };
+};
+const resolveStatusTarget = (command = 'gstatus', args = [], currentChat = '') => {
+    const tokens = Array.isArray(args) ? args : String(args || '').split(/\s+/);
+    if (String(command).toLowerCase() === 'gstatusall') return 'all';
+    const idToken = tokens.find(token => /^id.+@g\.us$/i.test(String(token)));
+    return idToken ? String(idToken).slice(2) : currentChat;
 };
 
 // True when the sender is a group admin of the given group (checked by JID
@@ -178,18 +199,19 @@ function buildGroupStatusTextMessage(text, preview) {
 
 module.exports = {
     name: 'gstatus',
-    alias: ['groupstatus', 'gs'],
+    alias: ['groupstatus', 'gs', 'gstatusall'],
     desc: 'Post a status to the group',
     category: 'Admin',
     groupOnly: true,
     adminOnly: true,
 
-    execute: async (sock, m, { text, args, reply }) => {
+    execute: async (sock, m, { text, args, reply, command }) => {
         try {
             const quoted = m.quoted || {};
             const chat = m.chat;
             const statusOptions = parseStatusOptions(text, args);
             text = statusOptions.cleanText;
+            const routeTarget = resolveStatusTarget(command || 'gstatus', args, chat);
 
             await sock.sendMessage(chat, {
                 react: { text: '📸', key: m.key }
@@ -217,21 +239,30 @@ module.exports = {
 
             // ─────────────────────────────
             // FEATURE: BROADCAST TO ALL GROUPS
-            // !gstatus text | all
-            // !gstatus | all (reply)
+            // !gstatus text | all, !gstatusall text, or !gstatusall -cp
             // ─────────────────────────────
-            if (text && text.includes('|')) {
-                const [left, right] = text.split('|').map(v => v.trim());
+            if (routeTarget === 'all' || (text && text.includes('|'))) {
+                const [left, right] = text.includes('|') ? text.split('|').map(v => v.trim()) : [text, 'all'];
 
                 if (right && right.toLowerCase() === 'all') {
-                    const messageText = left || quoted.text || quoted.caption || '';
+                    const messageText = left || statusOptions.caption || (statusOptions.copyCaption ? (quoted.caption || quoted.text || '') : '') || quoted.text || quoted.caption || '';
 
-                    if (!messageText) {
-                        return reply('`✘ Please provide a message to broadcast`');
+                    if (!messageText && !(quoted.mtype && typeof quoted.download === 'function')) {
+                        return reply('`✘ Please provide a message or reply to media to broadcast`');
                     }
 
                     const groups = await sock.groupFetchAllParticipating();
                     const groupIds = Object.keys(groups);
+                    let broadcastMedia = null;
+                    const quotedType = quoted.mtype;
+                    if (quotedType && ['imageMessage', 'videoMessage', 'audioMessage', 'documentMessage', 'stickerMessage'].includes(quotedType) && typeof quoted.download === 'function') {
+                        const media = await quoted.download();
+                        const caption = messageText || statusOptions.caption || (statusOptions.copyCaption ? (quoted.caption || quoted.text || '') : '') || quoted.caption || quoted.text || '';
+                        if (quotedType === 'imageMessage' || quotedType === 'stickerMessage') broadcastMedia = { image: media, caption };
+                        if (quotedType === 'videoMessage') broadcastMedia = { video: media, caption };
+                        if (quotedType === 'audioMessage') broadcastMedia = { audio: media, mimetype: quoted.mimetype || 'audio/ogg; codecs=opus', ptt: !!quoted.ptt };
+                        if (quotedType === 'documentMessage') broadcastMedia = { document: media, mimetype: quoted.mimetype, fileName: quoted.fileName || 'document', caption };
+                    }
 
                     if (!groupIds.length) {
                         return reply('`✘ Bot is not in any groups`');
@@ -261,7 +292,12 @@ module.exports = {
                             continue;
                         }
                         try {
-                            await relayAndTrack(sock, groupId, message);
+                            if (broadcastMedia) {
+                                const sent = await sendGroupStatusCompat(sock, groupId, broadcastMedia, statusOptions.backgroundColor);
+                                saveId(groupId, sent?.key?.id);
+                            } else {
+                                await relayAndTrack(sock, groupId, message);
+                            }
                             success++;
                         } catch (err) {
                             failed++;
@@ -281,7 +317,7 @@ module.exports = {
             // PARSE: text | jid
             // ─────────────────────────────
             let messageText = '';
-            let targetJid = chat;
+            let targetJid = routeTarget && routeTarget !== 'all' ? routeTarget : chat;
 
             if (text && text.includes('|')) {
                 const [left, right] = text.split('|').map(v => v.trim());
@@ -289,11 +325,11 @@ module.exports = {
                 if (!left && right) {
                     targetJid = right;
                 } else {
-                    messageText = left || '';
+                    messageText = left || statusOptions.caption || '';
                     if (right) targetJid = right;
                 }
             } else {
-                messageText = text || '';
+                messageText = text || statusOptions.caption || '';
             }
 
             if (!targetJid.endsWith('@g.us')) {
@@ -324,7 +360,7 @@ module.exports = {
             // IMAGE
             if (imageMsg) {
                 let media = await quoted.download();
-                const finalCaption = messageText || quoted.caption || quoted.text || '';
+                const finalCaption = messageText || (statusOptions.copyCaption ? (quoted.caption || quoted.text || '') : '') || quoted.caption || quoted.text || '';
                 try {
                     media = await sharp(media)
                         .resize({ width: 1920, height: 1080, fit: 'inside' })
@@ -342,7 +378,7 @@ module.exports = {
             // VIDEO
             if (videoMsg) {
                 const media = await quoted.download();
-                const finalCaption = messageText || quoted.caption || quoted.text || '';
+                const finalCaption = messageText || (statusOptions.copyCaption ? (quoted.caption || quoted.text || '') : '') || quoted.caption || quoted.text || '';
                 const vidMsg = await sendGroupStatusCompat(sock, targetJid, {
                     video: media,
                     caption: finalCaption
@@ -418,19 +454,24 @@ module.exports = {
   ✦  GROUP STATUS
 ─────────────────
 ▸ !gstatus <text>
-▸ !gstatus <url>  ← with rich preview
-▸ Reply to image + .gstatus [caption]
-▸ Reply to video + .gstatus [caption]
-▸ Reply to audio + .gstatus
-▸ Reply to document + .gstatus [caption]
-▸ !gstatus <text> | <groupJID>
-▸ !gstatus <text> | all  ← broadcast
-▸ !gstatus clear  ← delete all
+▸ !gstatus <url>  ← rich preview
+▸ Reply to image/video/audio/document + .gstatus [caption]
+▸ .gstatus --cp=<caption>  ← set caption explicitly
+▸ Reply to media + .gstatus -cp  ← copy its existing caption
+▸ .gstatus --bg=red|blue|green|yellow|purple|teal
+▸ .gstatus --bg=#RRGGBB  ← hex color; omitted = rotating color
+▸ .gstatus <text> | <groupJID>
+▸ .gstatus id<groupJID> <text>  ← direct target
+▸ .gstatusall <text>  ← broadcast to all groups
+▸ .gstatusall --cp=<caption> --bg=red  ← broadcast media/caption
+▸ .gstatus clear  ← delete tracked statuses
 ─────────────────
 EXAMPLES:
-!gstatus hello world | 120363425204601114@g.us
-!gstatus hello everyone | all
-!gstatus clear
+.gstatus hello world --bg=red
+.gstatus id120363425204601114@g.us hello
+.gstatus --cp=Fresh caption --bg=#112233
+.gstatusall hello everyone
+.gstatus clear
 ─────────────────`
             );
 
@@ -440,3 +481,7 @@ EXAMPLES:
         }
     }
 };
+
+module.exports.parseStatusOptions = parseStatusOptions;
+module.exports.resolveStatusTarget = resolveStatusTarget;
+module.exports.normalizeBackgroundColor = normalizeBackgroundColor;

--- a/src/Commands/Owner/mention.js
+++ b/src/Commands/Owner/mention.js
@@ -130,7 +130,7 @@ module.exports = {
             mentionConfig.text   = value;
             mentionConfig.emoji  = '';
             saveMentionConfig();
-            return reply(`${prefix}╭─❍ *MENTION*\n│\n│ ✦ Status : ON\n│ 𓄄 Action : TEXT\n│ ⚉ Text   : ${valueslice(0, 30)}${value.length > 30 ? '...' : ''}\n╰──────────────────`);
+            return reply(`${prefix}╭─❍ *MENTION*\n│\n│ ✦ Status : ON\n│ 𓄄 Action : TEXT\n│ ⚉ Text   : ${value.slice(0, 30)}${value.length > 30 ? '...' : ''}\n╰──────────────────`);
         }
 
         // HELP

--- a/src/Commands/Owner/testcard.js
+++ b/src/Commands/Owner/testcard.js
@@ -13,7 +13,7 @@ const testcard = {
     category: 'Owner',
     execute: async (sock, m, { reply }) => {
         if (typeof sock.sendRichButtonGrid !== 'function') {
-            return reply('sendRichButtonGrid is unavailable. Install @crysnovax/baileys@2.7.10 and restart CODY.');
+            return reply('sendRichButtonGrid is unavailable. Install the upgraded @crysnovax/plug runtime and restart CODY.');
         }
 
         const payload = {
@@ -42,10 +42,16 @@ const testcard = {
         try {
             const result = await sock.sendRichButtonGrid(m.chat, payload);
             const messageId = result?.key?.id || result?.messageId;
-            if (!messageId) {
-                throw new Error('rich-grid relay returned no message key');
+            const renderedCards = result?.message?.cards || result?.cards;
+            const cardCount = Array.isArray(renderedCards) ? renderedCards.length : 0;
+            const buttonCount = Array.isArray(renderedCards)
+                ? renderedCards.reduce((total, item) => total + (Array.isArray(item?.nativeFlow) ? item.nativeFlow.length : Array.isArray(item?.buttons) ? item.buttons.length : 0), 0)
+                : 0;
+            if (!messageId) throw new Error('rich-grid sender returned no message key');
+            if (cardCount !== payload.cards.length || buttonCount < payload.cards.reduce((n, card) => n + card.buttons.length, 0)) {
+                return reply(`Rich-grid relay returned message ${messageId}, but the returned payload was incomplete (${cardCount}/${payload.cards.length} cards, ${buttonCount} buttons). WhatsApp may not render this grid.`);
             }
-            return reply(`Meta AI-style rich-grid relay accepted (message ${messageId}). Check the chat for rendering.`);
+            return reply(`Rich-grid payload verified and relayed (message ${messageId}; ${cardCount} cards, ${buttonCount} buttons). This confirms CODY handed WhatsApp a complete grid; client rendering still depends on WhatsApp support.`);
         } catch (error) {
             return reply(`testcard failed: ${error?.message || error}`);
         }

--- a/tests/gstatus-grammar-and-mention.test.js
+++ b/tests/gstatus-grammar-and-mention.test.js
@@ -1,0 +1,87 @@
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'sharp') {
+        return () => ({ resize() { return this; }, jpeg() { return this; }, toBuffer: async () => Buffer.from('image') });
+    }
+    if (request === '@crysnovax/baileys') {
+        return {
+            prepareWAMessageMedia: async () => ({ imageMessage: {} }),
+            generateWAMessageContent: async () => ({ groupStatusMessageV2: {} }),
+            generateMessageIDV2: () => 'status-id',
+            buildLinkPreview: async url => ({ title: url, description: '' })
+        };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+};
+const gstatus = require('../src/Commands/Group/⤷.js');
+const mention = require('../src/Commands/Owner/mention.js');
+Module._load = originalLoad;
+
+test('gstatus parses named backgrounds and copy-caption options', () => {
+    assert.deepEqual(gstatus.parseStatusOptions('--bg=red --cp=Copied caption'), {
+        backgroundColor: '#FF6B6B',
+        copyCaption: false,
+        caption: 'Copied caption',
+        cleanText: ''
+    });
+    assert.deepEqual(gstatus.parseStatusOptions('-cp --bg=#112233'), {
+        backgroundColor: '#112233',
+        copyCaption: true,
+        caption: undefined,
+        cleanText: ''
+    });
+});
+
+test('gstatus recognizes gstatusall and id<JID> routing', () => {
+    assert.equal(gstatus.resolveStatusTarget('gstatusall', [], '12345@g.us'), 'all');
+    assert.equal(gstatus.resolveStatusTarget('gstatus', ['id120363425204601114@g.us'], '12345@g.us'), '120363425204601114@g.us');
+});
+
+test('mention text configuration does not throw valueSlice', async () => {
+    const replies = [];
+    await mention.execute({}, { key: { fromMe: true } }, {
+        args: ['-text', 'Busy, back later'],
+        prefix: '.',
+        reply: async value => replies.push(value)
+    });
+    assert.match(replies[0], /Busy, back later/);
+});
+
+test('gstatusall broadcasts replied media with explicit caption and named background', async () => {
+    const calls = [];
+    const replies = [];
+    const sock = {
+        user: { id: '99999@s.whatsapp.net' },
+        sendMessage: async () => {},
+        groupFetchAllParticipating: async () => ({ '111@g.us': {}, '222@g.us': {} }),
+        sendGroupStatus: async (jid, content, options) => {
+            calls.push({ jid, content, options });
+            return { key: { id: `status-${calls.length}` } };
+        }
+    };
+    const message = {
+        chat: '999@g.us',
+        sender: '99999@s.whatsapp.net',
+        key: { id: 'm1' },
+        quoted: {
+            mtype: 'imageMessage',
+            caption: 'old caption',
+            download: async () => Buffer.from('image')
+        }
+    };
+    await gstatus.execute(sock, message, {
+        command: 'gstatusall',
+        text: '',
+        args: ['--cp=New caption', '--bg=red'],
+        reply: async value => replies.push(value)
+    });
+    assert.equal(calls.length, 2);
+    assert.ok(calls.every(call => call.content.image.toString() === 'image'));
+    assert.ok(calls.every(call => call.content.caption === 'New caption'));
+    assert.ok(calls.every(call => call.options.backgroundColor === '#FF6B6B'));
+    assert.match(replies.at(-1), /Broadcast Done/i);
+});

--- a/tests/plogme-agent-upgrade.test.js
+++ b/tests/plogme-agent-upgrade.test.js
@@ -1,0 +1,62 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const missions = require('../src/Commands/Core/plogme-missions.js');
+const dependencies = require('../src/Commands/Core/plogme-dependencies.js');
+const { runHealthChecks } = require('../src/Commands/Core/plogme-health.js');
+const { buildProjectIndex } = require('../src/Commands/Core/plogme-project-index.js');
+const plogme = require('../src/Commands/Core/plogme.js');
+
+const transient = [missions.STORE_FILE, path.join(process.cwd(), 'database', 'plogme_project_index.json')];
+
+test.after(() => {
+    for (const file of transient) { try { fs.unlinkSync(file); } catch {} }
+});
+
+test('mission store persists steps, events, snapshots, and rollback', () => {
+    const target = path.join('database', 'plogme-agent-test.txt');
+    const absolute = path.join(process.cwd(), target);
+    fs.writeFileSync(absolute, 'before');
+    const mission = missions.createMission({ objective: 'test rollback', plan: ['edit', 'verify'] });
+    missions.setStep(mission.id, 1, 'running', 'Editing test file');
+    const snapshot = missions.snapshotFiles(mission.id, [target]);
+    fs.writeFileSync(absolute, 'after');
+    const result = missions.rollbackMission(mission.id, snapshot.id);
+    assert.equal(result.ok, true);
+    assert.equal(fs.readFileSync(absolute, 'utf8'), 'before');
+    assert.equal(missions.getMission(mission.id).status, 'running');
+    try { fs.unlinkSync(absolute); } catch {}
+});
+
+test('dependency manager rejects shell-injection package specs', () => {
+    assert.equal(dependencies.packageSpec('sharp'), 'sharp');
+    assert.equal(dependencies.packageSpec('@scope/pkg@1.2.3'), '@scope/pkg@1.2.3');
+    assert.equal(dependencies.packageSpec('x && rm -rf /'), null);
+    assert.equal(dependencies.packageSpec('../evil'), null);
+    assert.equal(dependencies.localStatus('definitely-not-installed-plogme-package').ok, true);
+});
+
+test('project index and health checks expose actionable state', () => {
+    const index = buildProjectIndex();
+    assert.ok(index.commandCount > 0);
+    assert.ok(Array.isArray(index.commands));
+    const health = runHealthChecks();
+    assert.ok(Array.isArray(health.checks));
+    assert.ok(health.checks.some(item => item.name === 'runtime'));
+});
+
+test('PLOGME executes mission and health actions with structured replies', async () => {
+    const replies = [];
+    const sock = { sendMessage: async () => ({ key: { id: 'reply-1' } }) };
+    const opts = { reply: async value => replies.push(String(value)) };
+    const missionResult = await plogme.executeIntent(sock, { chat: '12345@s.whatsapp.net' }, opts, {
+        action: 'mission_create', objective: 'verify agent tools', plan: ['inspect', 'test']
+    });
+    assert.equal(missionResult.handled, true);
+    assert.match(replies.join('\n'), /Mission created/);
+    const healthResult = await plogme.executeIntent(sock, { chat: '12345@s.whatsapp.net' }, opts, { action: 'health' });
+    assert.equal(healthResult.handled, true);
+    assert.match(replies.join('\n'), /CODY health/);
+});

--- a/tests/plogme-workspace.test.js
+++ b/tests/plogme-workspace.test.js
@@ -1,0 +1,36 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const plogme = require('../src/Commands/Core/plogme.js');
+
+test('PLOGME reports a live environment snapshot', () => {
+    const env = plogme.environmentSnapshot();
+    assert.equal(env.cwd, process.cwd());
+    assert.match(env.node, /^v\d+/);
+    assert.ok(Number.isInteger(env.files));
+    assert.ok(Object.hasOwn(env, 'memoryMb'));
+});
+
+test('PLOGME code search finds source lines inside the workspace', () => {
+    const results = plogme.searchWorkspace('value.slice', { codeOnly: true });
+    assert.ok(results.some(result => result.file.endsWith('src/Commands/Owner/mention.js')));
+});
+
+test('PLOGME send_file uses the live socket sender when opts.sendMessage is absent', async () => {
+    const replies = [];
+    const sent = [];
+    const sock = {
+        sendMessage: async (jid, content, options) => {
+            sent.push({ jid, content, options });
+            return { key: { id: 'file-1' } };
+        }
+    };
+    const result = await plogme.executeIntent(sock, { chat: '12345@s.whatsapp.net', key: { id: 'm1' } }, {
+        reply: async value => replies.push(value)
+    }, { action: 'send_file', path: 'src/Commands/Owner/mention.js' });
+    assert.equal(result.handled, true);
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].jid, '12345@s.whatsapp.net');
+    assert.equal(sent[0].content.fileName, 'mention.js');
+    assert.ok(Buffer.isBuffer(sent[0].content.document));
+    assert.ok(replies.some(reply => /File sent/i.test(reply)));
+});

--- a/tests/testcard-command.test.js
+++ b/tests/testcard-command.test.js
@@ -9,7 +9,10 @@ test('testcard sends the Meta AI-style image-backed rich grid', async () => {
     const sock = {
         sendRichButtonGrid: async (jid, payload) => {
             calls.push({ jid, payload });
-            return { key: { id: 'grid-1' } };
+            return {
+                key: { id: 'grid-1' },
+                message: { cards: payload.cards.map(card => ({ ...card, nativeFlow: card.buttons })) }
+            };
         },
         sendMessage: async () => {
             throw new Error('fallback sendMessage should not be used');
@@ -30,7 +33,7 @@ test('testcard sends the Meta AI-style image-backed rich grid', async () => {
     assert.ok(calls[0].payload.cards.every(card => card.buttons.length > 0));
     assert.match(calls[0].payload.text, /MENU/);
     assert.equal(replies.length, 1);
-    assert.match(replies[0], /relay accepted/i);
+    assert.match(replies[0], /payload verified and relayed/i);
 });
 
  test('testcard reports a clear error when the rich-grid helper is unavailable', async () => {


### PR DESCRIPTION
## Summary

- Document the complete `gstatus` grammar with named colors, copy-caption options, `gstatusall`, and `id<JID>` routing.
- Broadcast replied media through group status with explicit/copy captions and background selection.
- Make `testcard` validate returned card/button structure instead of claiming rendering from relay acceptance alone.
- Fix `.mention -text` (`valueSlice` regression).
- Add PLOGME workspace search, web search, environment snapshot, progress reporting, controlled tool creation, and socket sender fallback for file attachments.

## Validation

`node --check` passed for all modified JavaScript files. `node --test tests/*.test.js` passed: 19 tests, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace search, web search, environment inspection, progress updates, and JavaScript tool creation to the AI assistant.
  * Enhanced group status commands with target selection, captions, background colors, media broadcasting, and the `gstatusall` alias.

* **Bug Fixes**
  * Fixed text-action confirmation errors.
  * Improved runtime guidance and rich-button delivery verification, with clearer success and failure messages.

* **Tests**
  * Added coverage for workspace tools, group status options, mentions, media broadcasting, and rich-button verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->