### PR TITLE
fix: propagate live PLOGME attachment receipts

### DIFF
--- a/src/Commands/AI/plogme.js
+++ b/src/Commands/AI/plogme.js
@@ -182,7 +182,7 @@ module.exports = {
                 const restText = args.join(' ').trim();
                 if (restText && await plogme.handleControlIntent(sock, m, {
                     reply,
-                    sendMessage: async (jid, content, opts) => { try { await sock.sendMessage(jid, content, opts); } catch (e) {} }
+                    sendMessage: async (jid, content, opts) => sock.sendMessage(jid, content, opts)
                 }, 'plogme ' + restText)) return;
                 // Never dump the menu for a bare name-call / unknown sub — a
                 // short nudge keeps "plogme do this" from being answered with

--- a/tests/plogme-agent-upgrade.test.js
+++ b/tests/plogme-agent-upgrade.test.js
@@ -159,3 +159,23 @@ test('PLOGME normalizes malformed emphasis without altering ordinary bold marker
     assert.equal(plogme.normalizePlogmeFormatting('**Running** and ****wrong****'), '**Running** and **wrong**');
     assert.equal(plogme.normalizePlogmeFormatting('____ok____'), '__ok__');
 });
+
+test('live .plogme wrapper propagates the WhatsApp file receipt', async () => {
+    const aiCommand = require('../src/Commands/AI/plogme');
+    const replies = [];
+    const sent = [];
+    const sock = {
+        sendMessage: async (jid, content, options) => {
+            sent.push({ jid, content, options });
+            return { key: { id: 'wrapper-file-message-1' } };
+        }
+    };
+    await aiCommand.execute(sock, { chat: '12345@s.whatsapp.net', key: {} }, {
+        args: ['send', 'file', 'src/Commands/Owner/mention.js'],
+        prefix: '.',
+        reply: async value => replies.push(String(value))
+    });
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].content.fileName, 'mention.js');
+    assert.match(replies.at(-1), /Message ID:.*wrapper-file-message-1/);
+});


### PR DESCRIPTION
## Root cause

The explicit `.plogme` wrapper supplied a `sendMessage` callback that swallowed both the WhatsApp return value and every send error. The core agent could not prove delivery through the live wrapper.

## Fix

- Propagate the real `sock.sendMessage()` promise and receipt through the wrapper.
- Preserve the core `send_file` requirement for a returned WhatsApp message key.
- Keep failed or unverified sends from being reported as successful.

## Validation

`node --check` passed and the full CODY suite passed: 32 tests, 0 failures.