### PR TITLE
fix: make PLOGME code delivery CDN-first

### DIFF
--- a/src/Commands/Core/plogme.js
+++ b/src/Commands/Core/plogme.js
@@ -1931,43 +1931,42 @@ async function executeIntent(sock, m, opts, intent) {
                 let sent;
                 let deliveryMode = 'direct';
                 let cdnUrl = '';
-                let directError = null;
-                try {
-                    if (typeof opts.sendMessage !== 'function') throw new Error('WhatsApp sender is unavailable in this handler');
-                    sent = await opts.sendMessage(m.chat, {
-                        document: buffer,
-                        mimetype: mime,
-                        fileName: path.basename(resolved.abs)
-                    }, { quoted: m });
-                } catch (err) {
-                    directError = err;
-                }
-                // Code/text fallback: reuse /raw’s CDN upload contract, fetch the
-                // raw URL back, verify the bytes, then send that downloaded buffer.
-                // This avoids claiming a file was sent when direct media transport
-                // is unavailable while preserving the original filename.
-                if (directError && isTextFilePath(resolved.abs) && (CDN_BASE || typeof opts.cdnUpload === 'function')) {
+                if (isTextFilePath(resolved.abs)) {
+                    // Code/text files always use the proven /raw → CDN URL →
+                    // downloader-style round trip. Direct document transport is
+                    // intentionally not attempted for this class of file.
                     try {
-                        await reportProgress(opts, `direct attachment failed; using verified CDN fallback for ${resolved.display}`);
+                        if (!CDN_BASE && typeof opts.cdnUpload !== 'function') throw new Error('CDN_URL is not configured');
+                        await reportProgress(opts, `uploading ${resolved.display} to the verified CDN path`);
                         const uploaded = typeof opts.cdnUpload === 'function'
                             ? await opts.cdnUpload(buffer, path.basename(resolved.abs), mime)
                             : await uploadTextToCdn(buffer, path.basename(resolved.abs), mime);
-                        if (!uploaded?.url || !Buffer.isBuffer(uploaded.buffer)) throw new Error('CDN fallback did not return a verified buffer and URL');
-                        if (!uploaded.buffer.equals(buffer)) throw new Error('CDN fallback byte verification failed');
+                        if (!uploaded?.url || !Buffer.isBuffer(uploaded.buffer)) throw new Error('CDN did not return a verified buffer and URL');
+                        if (!uploaded.buffer.equals(buffer)) throw new Error('CDN round-trip byte verification failed');
                         cdnUrl = uploaded.url;
+                        if (typeof opts.sendMessage !== 'function') throw new Error('WhatsApp sender is unavailable in this handler');
                         sent = await opts.sendMessage(m.chat, {
                             document: uploaded.buffer,
                             mimetype: mime,
                             fileName: path.basename(resolved.abs)
                         }, { quoted: m });
                         deliveryMode = 'cdn';
-                    } catch (fallbackError) {
-                        await opts.reply(`_✘ Direct and CDN file delivery failed:_ ${fallbackError.message}`);
+                    } catch (cdnError) {
+                        await opts.reply(`_✘ Verified CDN file delivery failed:_ ${cdnError.message}`);
                         return { handled: true };
                     }
-                } else if (directError) {
-                    await opts.reply(`_✘ Failed to send file:_ ${directError.message}`);
-                    return { handled: true };
+                } else {
+                    try {
+                        if (typeof opts.sendMessage !== 'function') throw new Error('WhatsApp sender is unavailable in this handler');
+                        sent = await opts.sendMessage(m.chat, {
+                            document: buffer,
+                            mimetype: mime,
+                            fileName: path.basename(resolved.abs)
+                        }, { quoted: m });
+                    } catch (directError) {
+                        await opts.reply(`_✘ Failed to send file:_ ${directError.message}`);
+                        return { handled: true };
+                    }
                 }
                 const messageId = sent?.key?.id || sent?.messageId || sent?.id;
                 if (!messageId) {

--- a/tests/plogme-agent-upgrade.test.js
+++ b/tests/plogme-agent-upgrade.test.js
@@ -164,20 +164,24 @@ test('live .plogme wrapper propagates the WhatsApp file receipt', async () => {
     const aiCommand = require('../src/Commands/AI/plogme');
     const replies = [];
     const sent = [];
+    const binaryPath = path.join(process.cwd(), 'database', 'plogme-wrapper-test.bin');
+    fs.writeFileSync(binaryPath, Buffer.from([0, 1, 2, 3]));
     const sock = {
         sendMessage: async (jid, content, options) => {
             sent.push({ jid, content, options });
             return { key: { id: 'wrapper-file-message-1' } };
         }
     };
-    await aiCommand.execute(sock, { chat: '12345@s.whatsapp.net', key: {} }, {
-        args: ['send', 'file', 'src/Commands/Owner/mention.js'],
-        prefix: '.',
-        reply: async value => replies.push(String(value))
-    });
-    assert.equal(sent.length, 1);
-    assert.equal(sent[0].content.fileName, 'mention.js');
-    assert.match(replies.at(-1), /Message ID:.*wrapper-file-message-1/);
+    try {
+        await aiCommand.execute(sock, { chat: '12345@s.whatsapp.net', key: {} }, {
+            args: ['send', 'file', 'database/plogme-wrapper-test.bin'],
+            prefix: '.',
+            reply: async value => replies.push(String(value))
+        });
+        assert.equal(sent.length, 1);
+        assert.equal(sent[0].content.fileName, 'plogme-wrapper-test.bin');
+        assert.match(replies.at(-1), /Message ID:.*wrapper-file-message-1/);
+    } finally { try { fs.unlinkSync(binaryPath); } catch {} }
 });
 
 test('PLOGME converts raw upload URLs safely and classifies code files for CDN fallback', () => {
@@ -187,7 +191,7 @@ test('PLOGME converts raw upload URLs safely and classifies code files for CDN f
     assert.throws(() => plogme.toRawCdnUrl('file:///tmp/x.txt'), /non-HTTP URL/);
 });
 
-test('PLOGME uses the verified CDN fallback after direct code attachment failure', async () => {
+test('PLOGME uses the verified CDN path without attempting direct code attachment', async () => {
     const replies = [];
     const sent = [];
     const source = Buffer.from('module.exports = { name: \'cdn-fallback-test\' };');
@@ -195,7 +199,6 @@ test('PLOGME uses the verified CDN fallback after direct code attachment failure
         reply: async value => replies.push(String(value)),
         sendMessage: async (jid, content) => {
             sent.push({ jid, content });
-            if (sent.length === 1) throw new Error('direct upload unavailable');
             return { key: { id: 'cdn-message-1' } };
         },
         cdnUpload: async (buffer, filename) => {
@@ -205,8 +208,8 @@ test('PLOGME uses the verified CDN fallback after direct code attachment failure
         }
     }, { action: 'send_file', path: 'src/Commands/Owner/mention.js' });
     assert.equal(result.handled, true);
-    assert.equal(sent.length, 2);
-    assert.equal(sent[1].content.fileName, 'mention.js');
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].content.fileName, 'mention.js');
     assert.match(replies.at(-1), /Delivery:\* cdn/);
     assert.match(replies.at(-1), /cdn-message-1/);
 });

--- a/tests/plogme-agent-upgrade.test.js
+++ b/tests/plogme-agent-upgrade.test.js
@@ -213,3 +213,31 @@ test('PLOGME uses the verified CDN path without attempting direct code attachmen
     assert.match(replies.at(-1), /Delivery:\* cdn/);
     assert.match(replies.at(-1), /cdn-message-1/);
 });
+
+test('PLOGME keeps the file mission alive until CDN processing and send receipt finish', async () => {
+    const replies = [];
+    const sent = [];
+    let releaseUpload;
+    let settled = false;
+    const uploadPending = new Promise(resolve => { releaseUpload = resolve; });
+    const pending = plogme.executeIntent({}, { chat: '12345@s.whatsapp.net' }, {
+        reply: async value => replies.push(String(value)),
+        cdnUpload: async buffer => {
+            await uploadPending;
+            return { url: 'https://cdn.crysnovax.link/raw/lifecycle.txt', buffer: Buffer.from(buffer) };
+        },
+        sendMessage: async (jid, content) => {
+            sent.push({ jid, content });
+            return { key: { id: 'lifecycle-message-1' } };
+        }
+    }, { action: 'send_file', path: 'src/Commands/Owner/mention.js' }).then(value => { settled = true; return value; });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(settled, false);
+    assert.ok(replies.some(reply => /starting send file|uploading/.test(reply)));
+    releaseUpload();
+    const result = await pending;
+    assert.equal(result.handled, true);
+    assert.equal(settled, true);
+    assert.equal(sent.length, 1);
+    assert.match(replies.at(-1), /lifecycle-message-1/);
+});


### PR DESCRIPTION
## Change

Code and text files now always use CODY’s proven raw/CDN upload-download-send path. PLOGME no longer attempts direct WhatsApp document delivery for this file class.

## Flow

- Read the real file bytes from the runtime workspace.
- Upload as a `.txt` multipart file to `CDN_URL/upload`.
- Convert the returned URL to `/raw/...txt`.
- Download and compare the bytes exactly.
- Send the verified buffer with the original filename.
- Report success only after a real WhatsApp message ID is returned.

Binary files retain the existing direct attachment path.

## Validation

Full local suite: 34 tests, 0 failures. Added no-direct-call coverage for code files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved text and code file delivery through verified CDN uploads and byte validation.
  * Added clearer reporting for delivery modes and CDN URLs.

* **Bug Fixes**
  * CDN delivery failures now return an immediate error instead of attempting an attachment fallback.
  * Improved handling of missing senders and message delivery errors.
  * File delivery status now remains pending until upload and message receipt are complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->