### PR TITLE
feat: add Gen4 RichMenu on Baileys 2.7.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",
-        "@crysnovax/baileys": "^2.7.5",
+        "@crysnovax/baileys": "^2.7.11",
         "@distube/ytdl-core": "^4.16.12",
         "@faker-js/faker": "^10.3.0",
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
@@ -279,11 +279,11 @@
       }
     },
     "node_modules/@crysnovax/baileys": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/@crysnovax/baileys/-/baileys-2.7.5.tgz",
-      "integrity": "sha512-1fMXGCBtIQKXt8ERIwQlFR1KzPu/Lm+O968jHobaYzfMyELCHn7a/5LWLwVtfd/AhX6du5uAD3r69mJHUZtKgg==",
+      "version": "2.7.11",
+      "resolved": "https://registry.npmjs.org/@crysnovax/baileys/-/baileys-2.7.11.tgz",
+      "integrity": "sha512-D6/om6dk+R1L2BXNJ2tAm+ESeLm0ch53auo4I7K+oglikuBxCSzOAYU8NYCrop1vcWIQJfPWJ6J/Yu4Cqk/rkg==",
       "hasInstallScript": true,
-      "license": "MIT",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",
         "@cacheable/node-cache": "^1.4.0",
@@ -755,9 +755,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -773,9 +770,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -793,9 +787,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -811,9 +802,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -831,9 +819,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -849,9 +834,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -869,9 +851,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -888,9 +867,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -906,9 +882,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -932,9 +905,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -956,9 +926,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -982,9 +949,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1006,9 +970,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1032,9 +993,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1057,9 +1015,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1081,9 +1036,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1851,9 +1803,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1873,9 +1822,6 @@
       "integrity": "sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1897,9 +1843,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1920,9 +1863,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1942,9 +1882,6 @@
       "integrity": "sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8259,9 +8196,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8283,9 +8217,6 @@
       "integrity": "sha512-bnGG+MJjdX70mAQcSLxgeJco11G+MxTz+ebxlz8Y3dxyeb3Nkl7LgLI0mXupoO+u1wRNx/iRj5yHtzA4sde1yA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -8309,9 +8240,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8333,9 +8261,6 @@
       "integrity": "sha512-3NR1mxFsaSgMMzz1bAnnKbSAI+lHXVTqAHgc1bgzjHuXjo4hlscpUxc0vFSAPKI3yuzdzcZOkq7nDPrP2F8Jgw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -8359,9 +8284,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8384,9 +8306,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8408,9 +8327,6 @@
       "integrity": "sha512-Fndk/4Zq3vAc4G/qyfXASbS3HBZbKrlnKZLEJzPLrXoJuipFNNwTes71+Ki1hwYW5lch26niRYoZFAtZVf3EGA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -8438,9 +8354,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8466,9 +8379,6 @@
       "integrity": "sha512-MBoInDXDppMfhSzbMmOQtGfloVAflS2rP1qPcUIiITMi36Mm5YR7r0ASND99razjQUpHTzjrU1flO76hKvP5RA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -8496,9 +8406,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8525,9 +8432,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8553,9 +8457,6 @@
       "integrity": "sha512-+ZLE3SQmSL+Fn1gmSaM8uFusW5Y3J9VOf+wMGNnTtJUMUxFhv+P4UPaYEYT8tqnyYVaOVGgMN/zsOxn9pSsO2A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@adiwajshing/keyed-db": "^0.2.4",
-    "@crysnovax/baileys": "^2.7.10",
+    "@crysnovax/baileys": "^2.7.11",
     "@distube/ytdl-core": "^4.16.12",
     "@faker-js/faker": "^10.3.0",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",

--- a/src/Commands/Owner/gen4.js
+++ b/src/Commands/Owner/gen4.js
@@ -38,7 +38,7 @@ const gen4 = {
             },
             footer: {
                 text: 'Telegram channel',
-                url: 'https://t.me/crysnovax'
+                url: 'https://t.me/CRYSNOVA_AI'
             }
         };
 

--- a/src/Commands/Owner/gen4.js
+++ b/src/Commands/Owner/gen4.js
@@ -1,0 +1,56 @@
+const MENU_IMAGE = 'https://cdn.crysnovax.link/files/1786913837400-12ad05cc-468a-4d71-8de8-1e5a11b48f3b.jpeg';
+
+const gen4 = {
+    name: 'gen4',
+    alias: ['gen4menu', 'richmenu'],
+    desc: 'Send the Gen4 Meta AI-style RichMenu',
+    category: 'Owner',
+    execute: async (sock, m, { reply }) => {
+        if (typeof sock.richMenu !== 'function') {
+            return reply('sock.richMenu is unavailable. Install @crysnovax/baileys 2.7.11 or newer and restart CODY.');
+        }
+
+        const payload = {
+            header: {
+                title: 'Rich Menu',
+                image: { url: MENU_IMAGE, mime_type: 'image/jpeg' }
+            },
+            body: {
+                row: true,
+                cards: [
+                    {
+                        title: 'Menu 1',
+                        buttons: [
+                            { id: 'menu2', text: 'menu2' },
+                            { id: 'menu3', text: 'menu3' },
+                            { id: 'rich3', text: 'rich3' }
+                        ]
+                    },
+                    {
+                        title: 'Menu 2',
+                        buttons: [
+                            { id: 'test', text: 'test' },
+                            { id: 'me', text: 'me' },
+                            { id: 'rich2', text: 'rich2' }
+                        ]
+                    }
+                ]
+            },
+            footer: {
+                text: 'Telegram channel',
+                url: 'https://t.me/crysnovax'
+            }
+        };
+
+        try {
+            const result = await sock.richMenu(m.chat, payload);
+            const messageId = result?.key?.id || result?.messageId || result?.id;
+            return reply(`Gen4 RichMenu requested${messageId ? ` and relayed (message ${messageId})` : ' successfully'}. Client rendering depends on WhatsApp support.`);
+        }
+        catch (error) {
+            return reply(`gen4 failed: ${error?.message || error}`);
+        }
+    }
+};
+
+module.exports = gen4;

--- a/tests/gen4-command.test.js
+++ b/tests/gen4-command.test.js
@@ -24,7 +24,7 @@ test('gen4 sends the screenshot-style RichMenu through sock.richMenu', async () 
     assert.equal(calls[0].payload.body.cards.length, 2);
     assert.equal(calls[0].payload.body.cards[0].buttons.length, 3);
     assert.equal(calls[0].payload.body.cards[1].buttons[2].id, 'rich2');
-    assert.equal(calls[0].payload.footer.url, 'https://t.me/crysnovax');
+    assert.equal(calls[0].payload.footer.url, 'https://t.me/CRYSNOVA_AI');
     assert.match(replies[0], /gen4 richmenu requested.*gen4-1/i);
 });
 

--- a/tests/gen4-command.test.js
+++ b/tests/gen4-command.test.js
@@ -1,0 +1,41 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const gen4 = require('../src/Commands/Owner/gen4.js');
+
+test('gen4 sends the screenshot-style RichMenu through sock.richMenu', async () => {
+    const calls = [];
+    const replies = [];
+    const sock = {
+        richMenu: async (jid, payload) => {
+            calls.push({ jid, payload });
+            return { key: { id: 'gen4-1' } };
+        }
+    };
+
+    await gen4.execute(sock, { chat: '12345@g.us' }, {
+        reply: async value => replies.push(value)
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].jid, '12345@g.us');
+    assert.equal(calls[0].payload.header.title, 'Rich Menu');
+    assert.equal(calls[0].payload.header.image.mime_type, 'image/jpeg');
+    assert.equal(calls[0].payload.body.cards.length, 2);
+    assert.equal(calls[0].payload.body.cards[0].buttons.length, 3);
+    assert.equal(calls[0].payload.body.cards[1].buttons[2].id, 'rich2');
+    assert.equal(calls[0].payload.footer.url, 'https://t.me/crysnovax');
+    assert.match(replies[0], /gen4 richmenu requested.*gen4-1/i);
+});
+
+test('gen4 reports when the upgraded richMenu API is unavailable', async () => {
+    const replies = [];
+
+    await gen4.execute({}, { chat: '12345@s.whatsapp.net' }, {
+        reply: async value => replies.push(value)
+    });
+
+    assert.equal(replies.length, 1);
+    assert.match(replies[0], /sock\.richMenu/i);
+    assert.match(replies[0], /2\.7\.11/i);
+});


### PR DESCRIPTION
## Summary

- update CODY to @crysnovax/baileys 2.7.11
- regenerate package-lock and verify the installed runtime
- add owner-only .gen4/.gen4menu/.richmenu commands
- use the official CRYSNOVA_AI Telegram channel footer

## Validation

- focused command and eval tests pass
- installed runtime reports @crysnovax/baileys 2.7.11
- Gen4 RichMenu regression coverage included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an owner command that creates and sends a two-card RichMenu with images, interactive buttons, and a Telegram footer.
  - Displays returned message identifiers after successful delivery.
  - Provides clear error feedback when the required RichMenu capability is unavailable.

- **Tests**
  - Added coverage for successful RichMenu delivery, payload details, and unavailable API error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->