### PR TITLE
fix: route Gen4 deployment button replies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/src/Plugin/crysMsg.js
+++ b/src/Plugin/crysMsg.js
@@ -1,6 +1,7 @@
 // crysMsg.js
 const { getCommand } = require('./crysCmd');
 const { getVar }     = require('./configManager');
+const { normalizeDeployButton } = require('./deployButtonRouter');
 const chalk = require('chalk');
 const fs    = require('fs');
 const path  = require('path');
@@ -188,7 +189,12 @@ const handleMessage = async (sock, m, store) => {
         const isDual = isOwner || isDualUser(sender, store) ||
                        (altNum && isDualUser(altJid, store));
 
-        const body = m.text || '';
+        const rawBody = m.text || '';
+        // Gen4 rich-menu CTAs may arrive as ordinary conversation text on
+        // WhatsApp clients. Normalize exact deployment labels/callback IDs
+        // back into the command syntax before prefix parsing.
+        const normalizedDeployButton = normalizeDeployButton(rawBody);
+        const body = normalizedDeployButton || rawBody;
 
         // ── RAW EVAL TRIGGERS: $ (JS) and \ (Shell) — owner/dual only ──
         if (isOwner || isDual) {

--- a/src/Plugin/deployButtonRouter.js
+++ b/src/Plugin/deployButtonRouter.js
@@ -1,0 +1,30 @@
+const DEPLOY_BUTTON_COMMANDS = new Map([
+    ['step 1 · discord', '.deploy step1'],
+    ['step 1 - discord', '.deploy step1'],
+    ['step 1 discord', '.deploy step1'],
+    ['step 2 · panel', '.deploy step2'],
+    ['step 2 - panel', '.deploy step2'],
+    ['step 2 panel', '.deploy step2'],
+    ['step 3 · pair', '.deploy step3'],
+    ['step 3 - pair', '.deploy step3'],
+    ['step 3 pair', '.deploy step3'],
+    ['step 4 · upload', '.deploy step4'],
+    ['step 4 - upload', '.deploy step4'],
+    ['step 4 upload', '.deploy step4'],
+    ['help', '.deploy help'],
+    ['tutorials', '.deploy tutorials'],
+    ['back to menu', '.deploy menu'],
+    ['menu', '.deploy menu']
+]);
+
+const normalizeDeployButton = value => {
+    const text = String(value || '').trim();
+    if (!text) return null;
+    if (/^\.deploy\s+(step[1-4]|help|tutorials|menu)$/i.test(text)) return text;
+    if (/^deploy:(step[1-4]|help|tutorials|menu)$/i.test(text)) {
+        return `.deploy ${text.slice('deploy:'.length)}`;
+    }
+    return DEPLOY_BUTTON_COMMANDS.get(text.toLowerCase()) || null;
+};
+
+module.exports = { normalizeDeployButton, DEPLOY_BUTTON_COMMANDS };

--- a/tests/deploy-button-router.test.js
+++ b/tests/deploy-button-router.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { normalizeDeployButton } = require('../src/Plugin/deployButtonRouter');
+
+test('normalizes Gen4 deployment labels from WhatsApp conversation responses', () => {
+    assert.equal(normalizeDeployButton('Step 1 · Discord'), '.deploy step1');
+    assert.equal(normalizeDeployButton('Step 2 · Panel'), '.deploy step2');
+    assert.equal(normalizeDeployButton('Step 3 · Pair'), '.deploy step3');
+    assert.equal(normalizeDeployButton('Step 4 · Upload'), '.deploy step4');
+    assert.equal(normalizeDeployButton('Help'), '.deploy help');
+    assert.equal(normalizeDeployButton('Tutorials'), '.deploy tutorials');
+});
+
+test('normalizes callback IDs and preserves unrelated text', () => {
+    assert.equal(normalizeDeployButton('deploy:step3'), '.deploy step3');
+    assert.equal(normalizeDeployButton('.deploy step4'), '.deploy step4');
+    assert.equal(normalizeDeployButton('hello world'), null);
+    assert.equal(normalizeDeployButton('Step 9 · Other'), null);
+});


### PR DESCRIPTION
## Summary

- route Gen4 deployment button labels back into CODY commands
- support Step 1, Step 2, Step 3, Step 4, Help, Tutorials, and callback IDs
- keep local node_modules and environment files out of Git

## Validation

- 9 focused tests pass
- deploy, Gen4, testcard, and button-router syntax checks pass
- branch is based on the merged Gen4 deployment work in main