### PR TITLE
debug: trace Gen4 button delivery path

### DIFF
--- a/?.js
+++ b/?.js
@@ -10,6 +10,7 @@
 const chalk = require('chalk');
 const { setupStatusHandler } = require('./src/Plugin/statusHandler');
 const { getVar }             = require('./src/Plugin/configManager');
+const { normalizeDeployButtonMessage } = require('./src/Plugin/deployButtonRouter');
 
 const styles  = require("./src/Commands/Core/'.js");
 const botFont = require('./src/Commands/Bot/botfont.js');
@@ -258,6 +259,21 @@ setupPromotionGuard(sock);
 
             const m = await smsg(sock, mek, customStore);
             if (!m) return;
+
+            // Gen4 diagnostic: prove whether WhatsApp delivered the tap and
+            // expose the exact Baileys envelope before downstream plugins run.
+            const rawGen4Command = normalizeDeployButtonMessage(mek.message);
+            if (rawGen4Command) {
+                m.body = rawGen4Command;
+                m.text = rawGen4Command;
+                console.log('[GEN4 TRACE]', JSON.stringify({
+                    command: rawGen4Command,
+                    fromMe: Boolean(mek.key?.fromMe),
+                    mtype: m.mtype,
+                    chat: m.chat,
+                    messageKeys: Object.keys(mek.message || {})
+                }));
+            }
 
             // ── SAVE MODE — auto-block unsaved contacts that DM the bot (@crysnovax—FIX06-08-26) ──
             try {

--- a/src/Plugin/crysMsg.js
+++ b/src/Plugin/crysMsg.js
@@ -1,7 +1,7 @@
 // crysMsg.js
 const { getCommand } = require('./crysCmd');
 const { getVar }     = require('./configManager');
-const { normalizeDeployButton } = require('./deployButtonRouter');
+const { normalizeDeployButton, normalizeDeployButtonMessage } = require('./deployButtonRouter');
 const chalk = require('chalk');
 const fs    = require('fs');
 const path  = require('path');
@@ -193,7 +193,7 @@ const handleMessage = async (sock, m, store) => {
         // Gen4 rich-menu CTAs may arrive as ordinary conversation text on
         // WhatsApp clients. Normalize exact deployment labels/callback IDs
         // back into the command syntax before prefix parsing.
-        const normalizedDeployButton = normalizeDeployButton(rawBody);
+        const normalizedDeployButton = normalizeDeployButton(rawBody) || normalizeDeployButtonMessage(m.message);
         const body = normalizedDeployButton || rawBody;
 
         // ── RAW EVAL TRIGGERS: $ (JS) and \ (Shell) — owner/dual only ──

--- a/src/Plugin/deployButtonRouter.js
+++ b/src/Plugin/deployButtonRouter.js
@@ -27,4 +27,81 @@ const normalizeDeployButton = value => {
     return DEPLOY_BUTTON_COMMANDS.get(text.toLowerCase()) || null;
 };
 
-module.exports = { normalizeDeployButton, DEPLOY_BUTTON_COMMANDS };
+const parseJson = value => {
+    if (!value) return null;
+    if (Buffer.isBuffer(value)) value = value.toString('utf8');
+    if (typeof value !== 'string') return value;
+    try { return JSON.parse(value); } catch { return null; }
+};
+
+/**
+ * Extract a user-visible label or callback id from Baileys-normalized or raw
+ * WhatsApp interactive response messages. Gen4 rich-menu taps can be echoed as
+ * ordinary conversation text, but newer clients may use one of the response
+ * message envelopes below.
+ */
+const extractDeployButtonValues = message => {
+    const values = [];
+    const add = value => {
+        if (value !== undefined && value !== null && String(value).trim()) values.push(String(value).trim());
+    };
+    const visit = node => {
+        if (!node || typeof node !== 'object') return;
+        add(node.conversation);
+        add(node.text);
+        add(node.contentText);
+        add(node.selectedButtonId);
+        add(node.selectedDisplayText);
+        add(node.selectedId);
+        add(node.title);
+        add(node.buttonId);
+        add(node.id);
+        add(node.displayText);
+        add(node.singleSelectReply?.selectedRowId);
+        add(node.singleSelectReply?.selectedDisplayText);
+        add(node.nativeFlowResponseMessage?.name);
+        add(node.nativeFlowResponseMessage?.buttonParamsJson);
+        add(node.interactiveResponseMessage?.body?.text);
+        add(node.interactiveResponseMessage?.nativeFlowResponseMessage?.name);
+        add(node.interactiveResponseMessage?.nativeFlowResponseMessage?.buttonParamsJson);
+
+        for (const candidate of [
+            node.buttonParamsJson,
+            node.nativeFlowResponseMessage?.buttonParamsJson,
+            node.interactiveResponseMessage?.nativeFlowResponseMessage?.buttonParamsJson
+        ]) {
+            const parsed = parseJson(candidate);
+            if (parsed) {
+                add(parsed.id);
+                add(parsed.button_id);
+                add(parsed.buttonId);
+                add(parsed.selected_id);
+                add(parsed.display_text);
+                add(parsed.text);
+                visit(parsed);
+            }
+        }
+
+        for (const [key, child] of Object.entries(node)) {
+            if (key === 'contextInfo' || key === 'messageContextInfo') continue;
+            if (child && typeof child === 'object') visit(child);
+        }
+    };
+    visit(message);
+    return [...new Set(values)];
+};
+
+const normalizeDeployButtonMessage = message => {
+    for (const value of extractDeployButtonValues(message)) {
+        const command = normalizeDeployButton(value);
+        if (command) return command;
+    }
+    return null;
+};
+
+module.exports = {
+    normalizeDeployButton,
+    normalizeDeployButtonMessage,
+    extractDeployButtonValues,
+    DEPLOY_BUTTON_COMMANDS
+};

--- a/tests/deploy-button-router.test.js
+++ b/tests/deploy-button-router.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { normalizeDeployButton } = require('../src/Plugin/deployButtonRouter');
+const { normalizeDeployButton, normalizeDeployButtonMessage, extractDeployButtonValues } = require('../src/Plugin/deployButtonRouter');
 
 test('normalizes Gen4 deployment labels from WhatsApp conversation responses', () => {
     assert.equal(normalizeDeployButton('Step 1 · Discord'), '.deploy step1');
@@ -9,6 +9,28 @@ test('normalizes Gen4 deployment labels from WhatsApp conversation responses', (
     assert.equal(normalizeDeployButton('Step 4 · Upload'), '.deploy step4');
     assert.equal(normalizeDeployButton('Help'), '.deploy help');
     assert.equal(normalizeDeployButton('Tutorials'), '.deploy tutorials');
+});
+
+test('normalizes Baileys buttons and template response envelopes', () => {
+    assert.equal(normalizeDeployButtonMessage({ buttonsResponseMessage: {
+        selectedButtonId: 'Step 1 · Discord',
+        selectedDisplayText: 'Discord'
+    }}), '.deploy step1');
+    assert.equal(normalizeDeployButtonMessage({ templateButtonReplyMessage: {
+        selectedId: 'deploy:step3',
+        selectedDisplayText: 'Step 3 · Pair'
+    }}), '.deploy step3');
+});
+
+test('normalizes native-flow parameter JSON and raw conversation fallback', () => {
+    assert.equal(normalizeDeployButtonMessage({ conversation: 'Step 4 · Upload' }), '.deploy step4');
+    assert.equal(normalizeDeployButtonMessage({ interactiveResponseMessage: {
+        nativeFlowResponseMessage: {
+            name: 'quick_reply',
+            buttonParamsJson: JSON.stringify({ id: 'deploy:help', display_text: 'Help' })
+        }
+    }}), '.deploy help');
+    assert.ok(extractDeployButtonValues({ conversation: 'Tutorials' }).includes('Tutorials'));
 });
 
 test('normalizes callback IDs and preserves unrelated text', () => {


### PR DESCRIPTION
## Purpose

PR #41 was merged, but the deployed bot still does not answer Gen4 button taps. This patch traces the first receive boundary and normalizes raw Baileys envelopes before downstream handlers.

## Diagnostic output

When a deployment callback reaches CODY, the bot logs `[GEN4 TRACE]` with the normalized command, `fromMe`, message type, chat, and raw message keys.

## Validation

- `node --check ?.js` passes
- focused Gen4 tests pass: 9/9
- `git diff --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing deployment commands from interactive button messages.
  * Supports multiple message formats, including buttons, templates, native flows, and nested response envelopes.
  * Automatically converts recognized button selections into deploy commands.

* **Bug Fixes**
  * Improved command detection when deployment instructions are received through interactive messages.
  * Added diagnostic details for troubleshooting message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->