### PR TITLE
fix: return rich step responses after deploy taps

### DIFF
--- a/src/Commands/System/deploy.js
+++ b/src/Commands/System/deploy.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const MENU_IMAGE = 'https://cdn.crysnovax.link/files/1786913837400-12ad05cc-468a-4d71-8de8-1e5a11b48f3b.jpeg';
 const PANEL_URL = 'https://sl.crysnovax.link/PANEL2';
 const PAIR_URL = 'https://pair.crysnovax.link';
@@ -7,11 +9,24 @@ const DISCORD_URL = 'https://discord.com';
 
 const quoteOptions = message => ({ quoted: message });
 
-const sendRich = async (sock, message, payload) => {
+const sendRichMenu = async (sock, message, payload) => {
     if (typeof sock.richMenu !== 'function') {
-        throw new Error('sock.richMenu is unavailable. Install @crysnovax/baileys 2.7.11 or newer and restart CODY.');
+        throw new Error('sock.richMenu is unavailable. Install @crysnovax/baileys 2.7.12 or newer and restart CODY.');
     }
     return sock.richMenu(message.chat, payload, quoteOptions(message));
+};
+
+const sendRichStep = async (sock, message, step) => {
+    if (typeof sock.sendMessage !== 'function') {
+        throw new Error('sock.sendMessage is unavailable.');
+    }
+    return sock.sendMessage(message.chat, {
+        richResponse: [
+            { text: step.title },
+            { title: step.title, table: step.rows },
+            ...(step.code ? [{ code: [{ codeContent: step.code, highlightType: 0 }], language: 'javascript' }] : [])
+        ]
+    }, quoteOptions(message));
 };
 
 const button = (id, text) => ({ id: `.deploy ${id}`, text });
@@ -48,46 +63,64 @@ const menuPayload = {
     }
 };
 
-const stepPayload = (title, text, buttons) => ({
-    header: { title: `CODY AI · ${title}` },
-    body: {
-        row: true,
-        cards: [{ title, buttons }]
-    },
-    footer: { text: 'Back to deployment menu', url: 'https://sl.crysnovax.link/PANEL2' },
-    disclaimer: text
-});
+const tableRows = (...rows) => [
+    { isHeading: true, items: ['Item', 'Instruction'] },
+    ...rows.map(row => ({ items: row }))
+];
 
 const STEPS = {
     step1: {
         title: 'Step 1 · Discord account',
-        text: `Create an account at ${DISCORD_URL} if you do not already have one. Verify the email address, then keep the verified Discord account ready for panel verification.`,
-        buttons: [button('step2', 'Next · Panel'), button('menu', 'Back to menu')]
+        rows: tableRows(
+            ['Open', DISCORD_URL],
+            ['Account', 'Create an account if you do not already have one.'],
+            ['Verify', 'Verify the email address.'],
+            ['Ready', 'Keep the verified Discord account ready for panel verification.']
+        )
     },
     step2: {
         title: 'Step 2 · Speciefy panel',
-        text: `Visit ${PANEL_URL}, create an account, and verify it with Discord and your email address. After verification, create a Node.js server for CODY AI.`,
-        buttons: [button('step3', 'Next · Pair'), button('step1', 'Back · Discord'), button('menu', 'Menu')]
+        rows: tableRows(
+            ['Open', PANEL_URL],
+            ['Account', 'Create an account and verify it with Discord and your email address.'],
+            ['Server', 'Create a Node.js server for CODY AI.']
+        )
     },
     step3: {
         title: 'Step 3 · Pair and generate',
-        text: `Open ${PAIR_URL}. Fill in the required details and obtain your session ID. The owner number must begin with the country code and contain digits only: no plus sign, spaces, or formatting. Click Generate index.js, then download the generated file.`,
-        buttons: [button('step4', 'Next · Upload'), button('step2', 'Back · Panel'), button('menu', 'Menu')]
+        rows: tableRows(
+            ['Open', PAIR_URL],
+            ['Session', 'Fill in the required details and obtain your session ID.'],
+            ['Owner number', 'Use country-code digits only: no plus sign, spaces, or formatting.'],
+            ['Generate', 'Click Generate index.js, then download the generated file.']
+        ),
+        code: 'Owner number: 234xxxxxxxxx\nGenerated file: index.js'
     },
     step4: {
         title: 'Step 4 · Upload and start',
-        text: `Upload the downloaded index.js to the panel server, place it in the server root, and start the server. Watch the console until the bot connects. If the panel asks for a startup command, use node index.js.`,
-        buttons: [button('help', 'Help'), button('tutorials', 'Tutorials'), button('menu', 'Menu')]
+        rows: tableRows(
+            ['Upload', 'Upload index.js to the panel server root.'],
+            ['Start', 'Start the server and watch the console until the bot connects.'],
+            ['Command', 'If the panel asks for a startup command, use node index.js.']
+        ),
+        code: 'node index.js'
     },
     help: {
         title: 'Deployment help',
-        text: `If pairing fails, confirm that the number uses country code digits only and generate a fresh script. Confirm that Discord and panel email verification are complete, that index.js is in the server root, and that the server has started with node index.js.`,
-        buttons: [button('step1', 'Step 1'), button('step3', 'Pair'), button('menu', 'Menu')]
+        rows: tableRows(
+            ['Pairing', 'Confirm the owner number uses country-code digits only and generate a fresh script.'],
+            ['Verification', 'Confirm Discord and panel email verification are complete.'],
+            ['Panel', 'Confirm index.js is in the server root and the server starts with node index.js.']
+        )
     },
     tutorials: {
         title: 'Current tutorials',
-        text: `Current guide: ${TUTORIAL5_URL}\nAdditional valid guide: ${TUTORIAL3_URL}\nPairing site: ${PAIR_URL}\nPanel: ${PANEL_URL}`,
-        buttons: [button('step1', 'Start guide'), button('step3', 'Pair'), button('menu', 'Menu')]
+        rows: tableRows(
+            ['Primary', TUTORIAL5_URL],
+            ['Additional', TUTORIAL3_URL],
+            ['Pairing', PAIR_URL],
+            ['Panel', PANEL_URL]
+        )
     }
 };
 
@@ -102,8 +135,8 @@ const deployCommand = {
 
         try {
             if (action === 'menu' || action === 'start') {
-                await sendRich(sock, message, menuPayload);
-                return reply('Choose a deployment step from the Gen4 menu. Each button opens one quoted instruction.');
+                await sendRichMenu(sock, message, menuPayload);
+                return;
             }
 
             if (action === 'script') {
@@ -113,8 +146,9 @@ const deployCommand = {
             const step = STEPS[action];
             if (!step) return reply('Use .deploy or .pair to open the Gen4 guide. Available actions: step1, step2, step3, step4, help, tutorials.');
 
-            await sendRich(sock, message, stepPayload(step.title, step.text, step.buttons));
-            return reply(step.text);
+            // Button clicks deliberately leave Gen4 mode. Each click produces
+            // exactly one quoted richResponse containing the requested content.
+            await sendRichStep(sock, message, step);
         } catch (error) {
             return reply(`Deployment guide failed: ${error?.message || error}`);
         }
@@ -122,4 +156,4 @@ const deployCommand = {
 };
 
 module.exports = deployCommand;
-module.exports._internals = { menuPayload, STEPS, stepPayload };
+module.exports._internals = { menuPayload, STEPS, sendRichStep };

--- a/tests/deploy-command.test.js
+++ b/tests/deploy-command.test.js
@@ -2,7 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const deploy = require('../src/Commands/System/deploy');
 
-test('deploy opens the Gen4 menu with current panel and tutorial links', async () => {
+test('deploy opens the only Gen4 menu with current panel and tutorial links', async () => {
     const calls = [];
     const replies = [];
     const sock = {
@@ -21,36 +21,66 @@ test('deploy opens the Gen4 menu with current panel and tutorial links', async (
     assert.equal(payload.footer.url, 'https://sl.crysnovax.link/tutorial5');
     assert.equal(payload.body.cards[0].buttons[0].id, '.deploy step1');
     assert.equal(payload.body.cards[1].buttons[0].id, '.deploy step4');
-    assert.match(replies[0], /Choose a deployment step/);
+    assert.equal(replies.length, 0);
     assert.deepEqual(deploy.alias, ['pair']);
 });
 
-test('step3 returns current pairing instructions and routes back to the menu', async () => {
-    const calls = [];
-    const replies = [];
+test('step1 sends one quoted rich table and no second Gen4 menu', async () => {
+    const messages = [];
+    const menus = [];
     const sock = {
-        richMenu: async (...args) => {
-            calls.push(args);
+        richMenu: async (...args) => menus.push(args),
+        sendMessage: async (...args) => {
+            messages.push(args);
+            return { key: { id: 'deploy-step-1' } };
+        }
+    };
+    const message = { chat: '123@s.whatsapp.net', key: { id: 'request-2' }, message: { conversation: 'Step 1 · Discord' } };
+
+    await deploy.execute(sock, message, { args: ['step1'], reply: () => { throw new Error('step must not use plain reply'); } });
+
+    assert.equal(menus.length, 0);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0][0], message.chat);
+    assert.deepEqual(messages[0][2], { quoted: message });
+    const content = messages[0][1];
+    assert.ok(Array.isArray(content.richResponse));
+    assert.equal(content.richResponse.length, 2);
+    assert.match(content.richResponse[0].text, /Step 1/);
+    assert.equal(content.richResponse[1].title, 'Step 1 · Discord account');
+    assert.equal(content.richResponse[1].table[0].isHeading, true);
+    assert.match(content.richResponse[1].table[1].items[1], /discord\.com/);
+});
+
+test('step3 sends one rich table with code and no Gen4 menu', async () => {
+    const messages = [];
+    const menus = [];
+    const sock = {
+        richMenu: async (...args) => menus.push(args),
+        sendMessage: async (...args) => {
+            messages.push(args);
             return { key: { id: 'deploy-step-3' } };
         }
     };
-    const message = { chat: '123@s.whatsapp.net', key: { id: 'request-2' } };
+    const message = { chat: '123@s.whatsapp.net', key: { id: 'request-3' } };
 
-    await deploy.execute(sock, message, { args: ['step3'], reply: text => replies.push(text) });
+    await deploy.execute(sock, message, { args: ['step3'], reply: () => { throw new Error('step must not use plain reply'); } });
 
-    const payload = calls[0][1];
-    assert.equal(payload.header.title, 'CODY AI · Step 3 · Pair and generate');
-    assert.match(replies[0], /pair\.crysnovax\.link/);
-    assert.match(replies[0], /digits only/);
-    assert.ok(payload.body.cards[0].buttons.some(item => item.id === '.deploy menu'));
+    assert.equal(menus.length, 0);
+    assert.equal(messages.length, 1);
+    const content = messages[0][1];
+    assert.equal(content.richResponse.length, 3);
+    assert.match(content.richResponse[1].table[3].items[1], /country-code/);
+    assert.equal(content.richResponse[2].language, 'javascript');
+    assert.match(content.richResponse[2].code[0].codeContent, /index\.js/);
 });
 
 test('deploy reports a clear message when richMenu is unavailable', async () => {
     const replies = [];
-    const message = { chat: '123@s.whatsapp.net', key: { id: 'request-3' } };
+    const message = { chat: '123@s.whatsapp.net', key: { id: 'request-4' } };
 
     await deploy.execute({}, message, { args: [], reply: text => replies.push(text) });
 
     assert.match(replies[0], /richMenu is unavailable/);
-    assert.match(replies[0], /2\.7\.11/);
+    assert.match(replies[0], /2\.7\.12/);
 });


### PR DESCRIPTION
## Corrected interaction flow

- `.deploy` sends the single initial Gen4 RichMenu.
- Clicking `Step 1 · Discord` sends one quoted `richResponse` table containing the Discord instructions.
- Clicking `Step 2`, `Step 3`, `Step 4`, `Help`, or `Tutorials` sends one quoted rich response with the requested table and optional code block.
- Step responses do not send another Gen4 menu and do not include navigation buttons.

## Validation

- focused CODY suite: 17/17 passed
- syntax checks passed
- diff check passed

PR #44 was merged before this correction; this PR contains the required post-merge behavior change.