### PR TITLE
fix: reset deploy state between menu invocations

### DIFF
--- a/?.js
+++ b/?.js
@@ -260,6 +260,17 @@ setupPromotionGuard(sock);
             const m = await smsg(sock, mek, customStore);
             if (!m) return;
 
+            // CODY emits its own RichMenu and richResponse messages when
+            // emitOwnEvents is enabled. Those outgoing envelopes contain the
+            // same CTA/table text as the menu and must never be interpreted as
+            // a new button tap. Real self-chat taps arrive as conversation or
+            // interactive-response messages, not richResponse envelopes.
+            const ownRichResponse = Boolean(mek.key?.fromMe && (
+                mek.message?.richResponseMessage ||
+                mek.message?.botForwardedMessage?.message?.richResponseMessage
+            ));
+            if (ownRichResponse) return;
+
             // Gen4 diagnostic: prove whether WhatsApp delivered the tap and
             // expose the exact Baileys envelope before downstream plugins run.
             const rawGen4Command = normalizeDeployButtonMessage(mek.message);


### PR DESCRIPTION
## Fix

CODY was interpreting its own outgoing richResponse/RichMenu envelope as a new Gen4 button click when emitOwnEvents was enabled. That made the previous step appear persistent on the next `/deploy`.

This patch ignores only outgoing rich-response envelopes at the active event boundary. Real self-chat CTA echoes and interactive response messages still reach the Gen4 normalizer.

## Validation

- focused suite: 17/17 passed
- syntax checks passed
- diff check passed

PR #45 was already merged before this persistence fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outgoing rich responses and forwarded bot messages from being mistakenly processed as new button selections.
  * Preserved handling of genuine interactive responses in self-chat conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->