### PR TITLE
fix: refresh deploy menu callback identity

### DIFF
--- a/src/Commands/System/deploy.js
+++ b/src/Commands/System/deploy.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { randomBytes } = require('node:crypto');
+
 const MENU_IMAGE = 'https://cdn.crysnovax.link/files/1786913837400-12ad05cc-468a-4d71-8de8-1e5a11b48f3b.jpeg';
 const PANEL_URL = 'https://sl.crysnovax.link/PANEL2';
 const PAIR_URL = 'https://pair.crysnovax.link';
@@ -29,9 +31,15 @@ const sendRichStep = async (sock, message, step) => {
     }, quoteOptions(message));
 };
 
-const button = (id, text) => ({ id: `.deploy ${id}`, text });
+const button = (id, text, menuNonce) => ({
+    // WhatsApp clients cache CTA selection state by tool_call_id. A stable
+    // `.deploy step1` id therefore stays visually selected forever for some
+    // recipients. Keep the action stable but namespace every menu instance.
+    id: `.deploy ${id} --menu=${menuNonce}`,
+    text
+});
 
-const menuPayload = {
+const buildMenuPayload = (menuNonce = randomBytes(6).toString('hex')) => ({
     header: {
         title: 'CODY AI Deployment Guide',
         image: { url: MENU_IMAGE, mime_type: 'image/jpeg' }
@@ -42,17 +50,17 @@ const menuPayload = {
             {
                 title: 'Deployment Steps',
                 buttons: [
-                    button('step1', 'Step 1 · Discord'),
-                    button('step2', 'Step 2 · Panel'),
-                    button('step3', 'Step 3 · Pair')
+                    button('step1', 'Step 1 · Discord', menuNonce),
+                    button('step2', 'Step 2 · Panel', menuNonce),
+                    button('step3', 'Step 3 · Pair', menuNonce)
                 ]
             },
             {
                 title: 'Finish & Help',
                 buttons: [
-                    button('step4', 'Step 4 · Upload'),
-                    button('help', 'Help'),
-                    button('tutorials', 'Tutorials')
+                    button('step4', 'Step 4 · Upload', menuNonce),
+                    button('help', 'Help', menuNonce),
+                    button('tutorials', 'Tutorials', menuNonce)
                 ]
             }
         ]
@@ -61,7 +69,7 @@ const menuPayload = {
         text: 'Open a step for the current instructions',
         url: TUTORIAL5_URL
     }
-};
+});
 
 const tableRows = (...rows) => [
     { isHeading: true, items: ['Item', 'Instruction'] },
@@ -135,7 +143,7 @@ const deployCommand = {
 
         try {
             if (action === 'menu' || action === 'start') {
-                await sendRichMenu(sock, message, menuPayload);
+                await sendRichMenu(sock, message, buildMenuPayload());
                 return;
             }
 
@@ -156,4 +164,4 @@ const deployCommand = {
 };
 
 module.exports = deployCommand;
-module.exports._internals = { menuPayload, STEPS, sendRichStep };
+module.exports._internals = { buildMenuPayload, STEPS, sendRichStep };

--- a/src/Plugin/deployButtonRouter.js
+++ b/src/Plugin/deployButtonRouter.js
@@ -20,10 +20,10 @@ const DEPLOY_BUTTON_COMMANDS = new Map([
 const normalizeDeployButton = value => {
     const text = String(value || '').trim();
     if (!text) return null;
-    if (/^\.deploy\s+(step[1-4]|help|tutorials|menu)$/i.test(text)) return text;
-    if (/^deploy:(step[1-4]|help|tutorials|menu)$/i.test(text)) {
-        return `.deploy ${text.slice('deploy:'.length)}`;
-    }
+    const menuScoped = text.match(/^\.deploy\s+(step[1-4]|help|tutorials|menu)(?:\s+--menu=[a-z0-9_-]+)?$/i);
+    if (menuScoped) return `.deploy ${menuScoped[1].toLowerCase()}`;
+    const deployScoped = text.match(/^deploy:(step[1-4]|help|tutorials|menu)(?:\s+--menu=[a-z0-9_-]+)?$/i);
+    if (deployScoped) return `.deploy ${deployScoped[1].toLowerCase()}`;
     return DEPLOY_BUTTON_COMMANDS.get(text.toLowerCase()) || null;
 };
 

--- a/tests/deploy-button-router.test.js
+++ b/tests/deploy-button-router.test.js
@@ -33,6 +33,12 @@ test('normalizes native-flow parameter JSON and raw conversation fallback', () =
     assert.ok(extractDeployButtonValues({ conversation: 'Tutorials' }).includes('Tutorials'));
 });
 
+test('normalizes per-menu callback IDs', () => {
+    assert.equal(normalizeDeployButton('.deploy step1 --menu=abc123'), '.deploy step1');
+    assert.equal(normalizeDeployButton('deploy:step3 --menu=menu_456'), '.deploy step3');
+    assert.equal(normalizeDeployButton('.deploy step1 --menu=ABC!'), null);
+});
+
 test('normalizes callback IDs and preserves unrelated text', () => {
     assert.equal(normalizeDeployButton('deploy:step3'), '.deploy step3');
     assert.equal(normalizeDeployButton('.deploy step4'), '.deploy step4');

--- a/tests/deploy-command.test.js
+++ b/tests/deploy-command.test.js
@@ -19,10 +19,16 @@ test('deploy opens the only Gen4 menu with current panel and tutorial links', as
     const payload = calls[0][1];
     assert.equal(payload.header.title, 'CODY AI Deployment Guide');
     assert.equal(payload.footer.url, 'https://sl.crysnovax.link/tutorial5');
-    assert.equal(payload.body.cards[0].buttons[0].id, '.deploy step1');
-    assert.equal(payload.body.cards[1].buttons[0].id, '.deploy step4');
+    assert.match(payload.body.cards[0].buttons[0].id, /^\.deploy step1 --menu=[a-z0-9]+$/);
+    assert.match(payload.body.cards[1].buttons[0].id, /^\.deploy step4 --menu=[a-z0-9]+$/);
     assert.equal(replies.length, 0);
     assert.deepEqual(deploy.alias, ['pair']);
+});
+
+test('repeated menu builds receive fresh callback namespaces', () => {
+    const first = deploy._internals.buildMenuPayload();
+    const second = deploy._internals.buildMenuPayload();
+    assert.notEqual(first.body.cards[0].buttons[0].id, second.body.cards[0].buttons[0].id);
 });
 
 test('step1 sends one quoted rich table and no second Gen4 menu', async () => {


### PR DESCRIPTION
## Root cause

WhatsApp clients persist CTA selection state by callback/tool-call ID. Every `/deploy` menu previously reused IDs such as `.deploy step1`, so recipients who had clicked once could see that CTA as permanently selected on later menus.

## Fix

- namespace every menu callback with a fresh random `--menu=<nonce>` value
- normalize namespaced callbacks back to the stable deployment action
- verify repeated menu construction produces different callback IDs
- preserve the existing one-menu-plus-rich-step interaction contract

## Validation

- focused suite: 19/19 passed
- syntax checks passed
- diff check passed