### PR TITLE
fix: repair wallpaper, AntiForward, and AutoVV delivery

### DIFF
--- a/?.js
+++ b/?.js
@@ -573,6 +573,16 @@ try {
                 }
             } catch {}
 
+            // Run passive moderation and view-once hooks before command/chatbot
+            // handlers can short-circuit the event. These hooks inspect ordinary
+            // messages; command messages remain handled by handleMessage below.
+            try { await require('./src/Commands/Admin/antigm.js').handleAntiGM?.(sock, m, mek); } catch (err) { console.error('[ANTIGM ERROR]', err.message); }
+            try { await require('./src/Commands/Admin/antigroupstatus.js').handleAntiGroupStatus?.(sock, m, mek); } catch (err) { console.error('[ANTIGROUPSTATUS ERROR]', err.message); }
+            try { await require('./src/Commands/Admin/antibot.js').handleAntiBot?.(sock, m, mek); } catch (err) { console.error('[ANTIBOT ERROR]', err.message); }
+            try { await require('./src/Commands/Admin/antiforward.js').handleAntiForward?.(sock, m); } catch (err) { console.error('[ANTIFORWARD ERROR]', err.message); }
+            try { await require('./src/Commands/Admin/antilink.js').handleAntiLink?.(sock, m); } catch (err) { console.error('[ANTILINK ERROR]', err.message); }
+            try { await require('./src/Commands/Converter/vvcmd.js').handleVVReply?.(sock, m); } catch (err) { console.error('[VV ERROR]', err.message); }
+
             await handleMessage(sock, m, customStore);
 
             // --- plogme hook (dedupe + short-circuit) — runs BEFORE the old
@@ -612,40 +622,6 @@ try {
             } catch (err) {
                 console.error('[CHATBOT COMPAT ERROR]', err?.message || err);
             }
-
-            try {
-                const antigm = require('./src/Commands/Admin/antigm.js');
-                if (antigm?.handleAntiGM) await antigm.handleAntiGM(sock, m, mek);
-            } catch (err) { console.error('[ANTIGM ERROR]', err.message); }
-
-            try {
-                const antigroupstatus = require('./src/Commands/Admin/antigroupstatus.js');
-                if (antigroupstatus?.handleAntiGroupStatus) {
-                    await antigroupstatus.handleAntiGroupStatus(sock, m, mek);
-                }
-            } catch (err) { console.error('[ANTIGROUPSTATUS ERROR]', err.message); }
-
-            try {
-                const antibot = require('./src/Commands/Admin/antibot.js');
-                if (antibot?.handleAntiBot) {
-                    await antibot.handleAntiBot(sock, m, mek);
-                }
-            } catch (err) { console.error('[ANTIBOT ERROR]', err.message); }
-
-            try {
-                const antiforward = require('./src/Commands/Admin/antiforward.js');
-                if (antiforward?.handleAntiForward) await antiforward.handleAntiForward(sock, m);
-            } catch (err) { console.error('[ANTIFORWARD ERROR]', err.message); }
-
-            try {
-                const vvcmd = require('./src/Commands/Converter/vvcmd.js');
-                if (vvcmd?.handleVVReply) await vvcmd.handleVVReply(sock, m);
-            } catch {}
-
-            try {
-                const anti = require('./src/Commands/Admin/antilink.js');
-                if (anti?.handleAntiLink) await anti.handleAntiLink(sock, m);
-            } catch {}
 
             try {
                 if (m.isGroup && m.mentionedJid?.length) {

--- a/?.js
+++ b/?.js
@@ -579,8 +579,9 @@ try {
             try { await require('./src/Commands/Admin/antigm.js').handleAntiGM?.(sock, m, mek); } catch (err) { console.error('[ANTIGM ERROR]', err.message); }
             try { await require('./src/Commands/Admin/antigroupstatus.js').handleAntiGroupStatus?.(sock, m, mek); } catch (err) { console.error('[ANTIGROUPSTATUS ERROR]', err.message); }
             try { await require('./src/Commands/Admin/antibot.js').handleAntiBot?.(sock, m, mek); } catch (err) { console.error('[ANTIBOT ERROR]', err.message); }
-            try { await require('./src/Commands/Admin/antiforward.js').handleAntiForward?.(sock, m); } catch (err) { console.error('[ANTIFORWARD ERROR]', err.message); }
+            try { await require('./src/Commands/Admin/antiforward.js').handleAntiForward?.(sock, m, mek); } catch (err) { console.error('[ANTIFORWARD ERROR]', err.message); }
             try { await require('./src/Commands/Admin/antilink.js').handleAntiLink?.(sock, m); } catch (err) { console.error('[ANTILINK ERROR]', err.message); }
+            try { await require('./src/Commands/Converter/view-once.js').handleAutoVV?.(sock, m, mek); } catch (err) { console.error('[AUTOVV ERROR]', err.message); }
             try { await require('./src/Commands/Converter/vvcmd.js').handleVVReply?.(sock, m); } catch (err) { console.error('[VV ERROR]', err.message); }
 
             await handleMessage(sock, m, customStore);

--- a/src/Commands/Admin/antigm.js
+++ b/src/Commands/Admin/antigm.js
@@ -47,7 +47,7 @@ module.exports = {
 
         const sub = args[0]?.toLowerCase();
 
-        if (!sub) {
+        if (!sub || sub === 'status') {
             const cfg = db[group];
             let actionDisplay;
             if (cfg.action === 'delete') actionDisplay = ' ꙰⊕ DELETE';
@@ -108,13 +108,13 @@ module.exports = {
         }
         if (sub === 'resetwarn') {
             const mentioned = m.mentionedJid?.[0];
-            if (!mentioned) return reply(`${prefix}✐ Usage: antigm resetwarn @user`);
+            if (!mentioned) return reply('✐ Usage: .antigm resetwarn @user');
             const warns = loadWarns();
             const key = `${group}_${mentioned}`;
             if (warns[key]) {
                 delete warns[key];
                 saveWarns(warns);
-                return reply(`${prefix}✓ Warnings reset for @${mentioned.split('@')[0]}`);
+                return reply(`✓ Warnings reset for @${mentioned.split('@')[0]}`);
             }
             return reply(`✘ User has no warnings.`);
         }
@@ -204,7 +204,7 @@ module.exports.handleAntiGM = async function(sock, m, mek) {
         else if (action === 'tkick') {
             // temp kick — auto re-added after the duration (@crysnovax—FIX06-08-26)
             const { tkick, parseTime } = require('../../Plugin/tkick');
-            const durText = cfg.tkickDuration || '5m';
+            const durText = db[group].tkickDuration || '5m';
             const durMs = parseTime(durText) || 5 * 60 * 1000;
 
             await sock.sendMessage(group, {

--- a/src/Commands/Admin/antilink.js
+++ b/src/Commands/Admin/antilink.js
@@ -102,7 +102,7 @@ module.exports = {
 
         const sub = args[0]?.toLowerCase();
 
-        if (!sub) {
+        if (!sub || sub === 'status') {
             const whitelist = cfg.whitelist.length ? cfg.whitelist.map(u => `❏ ${u}`).join('\n') : '❏ none';
             const permit = cfg.permit.length ? cfg.permit.map(u => `❏ ${u}`).join('\n') : '❏ none';
             const domains = cfg.domains.length ? cfg.domains.map(d => `❏ ${d}`).join('\n') : '❏ none';
@@ -176,7 +176,7 @@ module.exports = {
         // ── NEW: ADD DOMAIN ──────────────────────────────────────────────
         if (sub === 'add') {
             const domain = args[1]?.trim().toLowerCase();
-            if (!domain) return reply(`${prefix}✐ Usage: antilink add <domain>\nExample: .antilink add github.com`);
+            if (!domain) return reply(`✐ Usage: .antilink add <domain>\nExample: .antilink add github.com`);
             
             // Remove http://, https://, www., and trailing slashes
             let cleanDomain = domain.replace(/^https?:\/\//i, '').replace(/^www\./, '').replace(/\/$/, '');
@@ -213,7 +213,7 @@ module.exports = {
 
         if (sub === 'allow') {
             const url = args[1]?.trim();
-            if (!url || !url.startsWith('http')) return reply(`${prefix}✐ Usage: antilink allow <full_link>\nExample: .antilink allow https://youtube.com/watch?v=abc123`);
+            if (!url || !url.startsWith('http')) return reply(`✐ Usage: .antilink allow <full_link>\nExample: .antilink allow https://youtube.com/watch?v=abc123`);
             if (cfg.whitelist.includes(url)) return reply('`✘ Link already allowed.`');
             cfg.whitelist.push(url);
             saveDB(db);
@@ -230,7 +230,7 @@ module.exports = {
         }
         if (sub === 'permit') {
             const url = args[1]?.trim();
-            if (!url || !url.startsWith('http')) return reply(`${prefix}✐ Usage: antilink permit <url_prefix>\nExample: .antilink permit https://whatsapp.com/channel`);
+            if (!url || !url.startsWith('http')) return reply(`✐ Usage: .antilink permit <url_prefix>\nExample: .antilink permit https://whatsapp.com/channel`);
             if (cfg.permit.includes(url)) return reply('`✘ URL prefix already permitted.`');
             cfg.permit.push(url);
             saveDB(db);
@@ -271,12 +271,12 @@ module.exports = {
             if (warns[key]) {
                 delete warns[key];
                 saveWarns(warns);
-                return reply(`${prefix}✓ Warnings reset for @${mentioned.split('@')[0]}`);
+                return reply(`✓ Warnings reset for @${mentioned.split('@')[0]}`);
             }
             return reply('`✘ User has no warnings.`');
         }
 
-        return reply(`${prefix}𒆜 Usage:\nantilink on/off\n.antilink delete/warn/kick/tkick 5m\n.antilink add <domain>\n.antilink remove <domain>\n.antilink allow <full_link>\n.antilink disallow <full_link>\n.antilink permit <url_prefix>\n.antilink unpermit <url_prefix>\n.antilink allowlist/permitlist/domainlist\n.antilink resetwarn @user\n.antilink clear`);
+        return reply(`𒆜 Usage:\nantilink on/off\n.antilink delete/warn/kick/tkick 5m\n.antilink add <domain>\n.antilink remove <domain>\n.antilink allow <full_link>\n.antilink disallow <full_link>\n.antilink permit <url_prefix>\n.antilink unpermit <url_prefix>\n.antilink allowlist/permitlist/domainlist\n.antilink resetwarn @user\n.antilink clear`);
     }
 };
 

--- a/src/Commands/Admin/settings.js
+++ b/src/Commands/Admin/settings.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+
+const readGroupConfig = name => {
+    try {
+        const file = path.join(process.cwd(), 'database', name);
+        return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : {};
+    } catch {
+        return {};
+    }
+};
+
+const status = (config, jid) => config?.[jid]?.enabled ? 'ON' : 'OFF';
+const action = (config, jid) => config?.[jid]?.action || 'delete';
+
+module.exports = {
+    name: 'settings',
+    alias: ['groupsettings', 'modsettings'],
+    desc: 'Show group moderators and moderation settings',
+    category: 'Admin',
+    groupOnly: true,
+    adminOnly: true,
+    reactions: { start: '⚙️', success: '📋' },
+    execute: async (sock, m, { reply }) => {
+        const metadata = await sock.groupMetadata(m.chat).catch(() => null);
+        if (!metadata) return reply('Unable to read group settings right now.');
+
+        const moderators = (metadata.participants || [])
+            .filter(participant => participant.admin === 'admin' || participant.admin === 'superadmin')
+            .map(participant => {
+                const jid = participant.id || participant.jid || '';
+                const role = participant.admin === 'superadmin' ? 'Owner' : 'Moderator';
+                return `• @${jid.split('@')[0]} — ${role}`;
+            });
+
+        const antiLink = readGroupConfig('antilink.json');
+        const antiGm = readGroupConfig('antigm.json');
+        const antiBot = readGroupConfig('antibot.json');
+        const antiForward = readGroupConfig('antiforward.json');
+        const antiGroupStatus = readGroupConfig('antigroupstatus.json');
+
+        const mentions = (metadata.participants || [])
+            .filter(participant => participant.admin === 'admin' || participant.admin === 'superadmin')
+            .map(participant => participant.id || participant.jid)
+            .filter(Boolean);
+
+        return reply(
+            `⚙️ *Group Settings*\n\n` +
+            `*Moderators (${moderators.length})*\n${moderators.length ? moderators.join('\n') : '• None'}\n\n` +
+            `*Anti Features*\n` +
+            `• AntiLink: ${status(antiLink, m.chat)} (${action(antiLink, m.chat)})\n` +
+            `• AntiGM: ${status(antiGm, m.chat)} (${action(antiGm, m.chat)})\n` +
+            `• AntiBot: ${status(antiBot, m.chat)} (${action(antiBot, m.chat)})\n` +
+            `• AntiForward: ${status(antiForward, m.chat)} (${action(antiForward, m.chat)})\n` +
+            `• AntiGroupStatus: ${status(antiGroupStatus, m.chat)} (${action(antiGroupStatus, m.chat)})`,
+            { mentions }
+        );
+    }
+};
+
+module.exports.status = status;
+module.exports.action = action;
+module.exports.readGroupConfig = readGroupConfig;
+
+module.exports;

--- a/src/Commands/Admin/warn.js
+++ b/src/Commands/Admin/warn.js
@@ -51,6 +51,12 @@ module.exports = [
 
             const reason = args.join(' ').trim() || 'No reason';
             const group = m.chat;
+
+            // When /warn is sent as a reply, remove the offending message first.
+            // A tag-only warning has no target message to delete.
+            if (m.quoted?.key) {
+                await sock.sendMessage(group, { delete: m.quoted.key }).catch(() => {});
+            }
             const targetNum = target.num;
             const targetJid = target.jid;
 

--- a/src/Commands/Converter/view-once.js
+++ b/src/Commands/Converter/view-once.js
@@ -30,7 +30,8 @@ module.exports = {
 
   execute: async (sock, m, { args, reply, prefix }) => {
     try {
-      const cmd = m.body.split(' ')[0].toLowerCase();
+      const rawBody = m.body || m.text || m.message?.conversation || m.message?.extendedTextMessage?.text || '';
+      const cmd = rawBody.trim().split(/\s+/)[0].toLowerCase();
       const sender = m.sender;
       const vvCmd = prefix + 'vv';
       const vvpCmd = prefix + 'vvp';
@@ -43,16 +44,23 @@ module.exports = {
       }
 
       // ───── MUST REPLY ─────
-      let quoted = m.message?.extendedTextMessage?.contextInfo?.quotedMessage;
+      let quoted = m.quoted?.message || m.message?.extendedTextMessage?.contextInfo?.quotedMessage;
       if (!quoted) {
         return reply('╭─❍ *CRYSNOVA AI V2.0*\n│ ✘ Reply to a view-once message.\n╰──────────────────');
       }
 
-      // unwrap ephemeral
-      if (quoted.ephemeralMessage) quoted = quoted.ephemeralMessage.message;
-
-      // unwrap viewOnce
-      if (quoted.viewOnceMessage) quoted = quoted.viewOnceMessage.message;
+      // Unwrap current ephemeral/view-once envelopes.
+      let unwrapped = true;
+      while (unwrapped && quoted) {
+        unwrapped = false;
+        for (const key of ['ephemeralMessage', 'viewOnceMessage', 'viewOnceMessageV2', 'viewOnceMessageV2Extension', 'documentWithCaptionMessage']) {
+          if (quoted[key]?.message) {
+            quoted = quoted[key].message;
+            unwrapped = true;
+            break;
+          }
+        }
+      }
 
       const type = Object.keys(quoted)[0];
 

--- a/src/Commands/Converter/view-once.js
+++ b/src/Commands/Converter/view-once.js
@@ -3,8 +3,10 @@ const path = require('path');
 const { downloadContentFromMessage } = require('@crysnovax/baileys');
 
 const DATA_FILE = path.join(__dirname, '../../../database/vv-reactions.json');
+const AUTOVV_FILE = path.join(__dirname, '../../../database/autovv.json');
 
 let reactionTriggers = {};
+let autoVVChats = {};
 let listenerAttached = false;
 
 try {
@@ -12,15 +14,45 @@ try {
     reactionTriggers = JSON.parse(fs.readFileSync(DATA_FILE));
   }
 } catch {}
+try {
+  if (fs.existsSync(AUTOVV_FILE)) autoVVChats = JSON.parse(fs.readFileSync(AUTOVV_FILE, 'utf8'));
+} catch {}
 
 function saveTriggers() {
   fs.mkdirSync(path.dirname(DATA_FILE), { recursive: true });
   fs.writeFileSync(DATA_FILE, JSON.stringify(reactionTriggers, null, 2));
 }
+function saveAutoVV() {
+  fs.mkdirSync(path.dirname(AUTOVV_FILE), { recursive: true });
+  fs.writeFileSync(AUTOVV_FILE, JSON.stringify(autoVVChats, null, 2));
+}
+function unwrapViewOnce(message) {
+  let content = message;
+  let changed = true;
+  while (changed && content) {
+    changed = false;
+    for (const key of ['ephemeralMessage', 'viewOnceMessage', 'viewOnceMessageV2', 'viewOnceMessageV2Extension', 'documentWithCaptionMessage']) {
+      if (content[key]?.message) {
+        content = content[key].message;
+        changed = true;
+        break;
+      }
+    }
+  }
+  return content;
+}
+async function downloadMedia(content) {
+  const type = Object.keys(content || {})[0];
+  if (!['imageMessage', 'videoMessage', 'stickerMessage', 'audioMessage'].includes(type)) return null;
+  const stream = await downloadContentFromMessage(content[type], type.replace('Message', '').toLowerCase());
+  const chunks = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  return { type, buffer: Buffer.concat(chunks) };
+}
 
 module.exports = {
   name: 'vv',
-  alias: ['viewonce', 'vview', 'vvp'],
+  alias: ['viewonce', 'vview', 'vvp', 'autovv'],
   category: 'media',
   owner: true,
   reactions: {
@@ -35,6 +67,16 @@ module.exports = {
       const sender = m.sender;
       const vvCmd = prefix + 'vv';
       const vvpCmd = prefix + 'vvp';
+      const autovvCmd = prefix + 'autovv';
+
+      if (cmd === autovvCmd) {
+        const mode = (args[0] || 'status').toLowerCase();
+        if (!['on', 'off', 'status'].includes(mode)) return reply(`Usage: ${autovvCmd} on | off | status`);
+        if (mode === 'status') return reply(`AutoVV is ${autoVVChats[m.chat] ? 'ON' : 'OFF'} in this chat.`);
+        autoVVChats[m.chat] = mode === 'on';
+        saveAutoVV();
+        return reply(`AutoVV ${mode === 'on' ? 'enabled' : 'disabled'} in this chat.`);
+      }
 
       // ───── SET REACTION TRIGGER ─────
       if (cmd === vvCmd && args[0] === 'cmd' && args[1]) {
@@ -96,11 +138,9 @@ module.exports = {
 
       // ───── PRIVATE (.vvp) ─────
       if (cmd === vvpCmd) {
-        await sock.sendMessage(sender, {
-          [sendType]: buffer,
-          caption: `╭─❍ *CRYSNOVA AI V2.0*\n│ ✓ View-once saved privately.\n╰──────────────────`
-        });
-        return reply('╭─❍ *CRYSNOVA AI V2.0*\n│ ✓ Sent to your DM.\n╰──────────────────');
+        await sock.sendMessage(sender, { [sendType]: buffer });
+        await sock.sendMessage(m.chat, { react: { text: '✅', key: m.key } }).catch(() => {});
+        return;
       }
 
       // ───── NORMAL (.vv) ─────
@@ -168,5 +208,25 @@ module.exports = {
       console.error('[VV ERROR]', err);
       reply('╭─❍ *CRYSNOVA AI V2.0*\n│ ✘ Error unlocking view-once.\n╰──────────────────');
     }
+  }
+};
+
+// Called before command dispatch so AutoVV also handles view-once media
+// messages that contain no text or command prefix.
+module.exports.handleAutoVV = async function handleAutoVV(sock, m, mek) {
+  try {
+    const chat = m?.chat || mek?.key?.remoteJid;
+    if (!chat || !autoVVChats[chat] || mek?.key?.fromMe) return false;
+    const content = unwrapViewOnce(mek?.message || m?.message);
+    const media = await downloadMedia(content);
+    if (!media) return false;
+    const recipient = m?.sender || mek?.key?.participant || chat;
+    const sendType = media.type.replace('Message', '').toLowerCase();
+    await sock.sendMessage(recipient, { [sendType]: media.buffer });
+    await sock.sendMessage(chat, { react: { text: '👁️', key: m?.key || mek?.key } }).catch(() => {});
+    return true;
+  } catch (error) {
+    console.error('[AUTOVV ERROR]', error.message);
+    return false;
   }
 };

--- a/src/Commands/Converter/vvcmd.js
+++ b/src/Commands/Converter/vvcmd.js
@@ -31,15 +31,23 @@ module.exports.handleVVReply = async function(sock, m) {
 
         // ── EXACT SAME AS .vvp FROM HERE ─────────────────────
 
-        // Must reply to something
-        let quoted = m.message?.extendedTextMessage?.contextInfo?.quotedMessage
+        // Must reply to something. Prefer the serialized quote, then fall
+        // back to the raw context envelope used by newer Baileys clients.
+        let quoted = m.quoted?.message || m.message?.extendedTextMessage?.contextInfo?.quotedMessage
         if (!quoted) return
 
-        // unwrap ephemeral
-        if (quoted.ephemeralMessage) quoted = quoted.ephemeralMessage.message
-
-        // unwrap viewOnce
-        if (quoted.viewOnceMessage)  quoted = quoted.viewOnceMessage.message
+        // Unwrap every envelope used by current WhatsApp clients.
+        let unwrapped = true
+        while (unwrapped && quoted) {
+            unwrapped = false
+            for (const key of ['ephemeralMessage', 'viewOnceMessage', 'viewOnceMessageV2', 'viewOnceMessageV2Extension', 'documentWithCaptionMessage']) {
+                if (quoted[key]?.message) {
+                    quoted = quoted[key].message
+                    unwrapped = true
+                    break
+                }
+            }
+        }
 
         const type = Object.keys(quoted)[0]
 

--- a/src/Commands/Fun/emojimix.js
+++ b/src/Commands/Fun/emojimix.js
@@ -1,4 +1,3 @@
-const fetch = require("node-fetch");
 const fs = require("fs");
 const path = require("path");
 const { exec } = require("child_process");
@@ -43,6 +42,7 @@ module.exports = {
                 `&q=${encodeURIComponent(emoji1)}_${encodeURIComponent(emoji2)}`;
 
             const response = await fetch(url);
+            if (!response.ok) throw new Error(`Tenor request failed (${response.status})`);
             const data = await response.json();
 
             if (!data.results?.length) {
@@ -61,7 +61,9 @@ module.exports = {
 
             /* Download image */
 
-            const imageBuffer = await (await fetch(imageUrl)).buffer();
+            const imageResponse = await fetch(imageUrl);
+            if (!imageResponse.ok) throw new Error(`Emoji image download failed (${imageResponse.status})`);
+            const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
             fs.writeFileSync(tempFile, imageBuffer);
 
             /* Convert to sticker */

--- a/src/Commands/Search/wp.js
+++ b/src/Commands/Search/wp.js
@@ -8,7 +8,7 @@ module.exports = {
     alias: ['wlp', 'wall',],
     desc: 'Search for beautiful wallpapers',
     category: 'Search',
-    usage: `${prefix}wallpaper <query>`,
+    usage: '.wallpaper <query>',
 
     execute: async (sock, m, { args, reply }) => {
         const query = args.join(' ').trim();
@@ -19,7 +19,7 @@ module.exports = {
             
             const res = await axios.get(`https://wallpaper.crysnovax.link/api/search?query=${encodeURIComponent(query)}`);
             const data = res.data;
-            const results = data?.results;
+            const results = Array.isArray(data) ? data : (data?.results || data?.data || data?.wallpapers);
 
             if (!Array.isArray(results) || results.length === 0) {
                 return reply(`✘ No wallpapers found for "${query}"`);
@@ -39,12 +39,23 @@ module.exports = {
                 }]
             }));
 
-            // Send as interactive carousel message
-            await sock.sendMessage(m.chat, {
-                text: `🖼️ *WALLPAPER SEARCH: ${query}*`,
-                footer: `Found ${results.length} results`,
-                cards: cards
-            }, { quoted: m });
+            // Generic sendMessage does not understand card arrays. Prefer the
+            // fork's rich-grid helper, then fall back to ordinary images.
+            if (typeof sock.sendRichButtonGrid === 'function') {
+                await sock.sendRichButtonGrid(m.chat, {
+                    text: `🖼️ *WALLPAPER SEARCH: ${query}*`,
+                    footer: `Found ${results.length} results`,
+                    cards
+                }, { quoted: m });
+            } else if (typeof sock.sendInteractiveCarousel === 'function') {
+                await sock.sendInteractiveCarousel(m.chat, {
+                    text: `🖼️ *WALLPAPER SEARCH: ${query}*`,
+                    footer: `Found ${results.length} results`,
+                    cards
+                }, { quoted: m });
+            } else {
+                throw new Error('No supported interactive wallpaper sender');
+            }
 
             await sock.sendMessage(m.chat, { react: { text: '✨', key: m.key } });
             
@@ -54,7 +65,8 @@ module.exports = {
             // Fallback to simple image messages if carousel fails
             try {
                 const res = await axios.get(`https://wallpaper.crysnovax.link/api/search?query=${encodeURIComponent(query)}`);
-                const results = res.data?.results || [];
+                const fallbackData = res.data;
+                const results = Array.isArray(fallbackData) ? fallbackData : (fallbackData?.results || fallbackData?.data || fallbackData?.wallpapers || []);
                 for (const wp of results.slice(0, 5)) {
                     await sock.sendMessage(m.chat, {
                         image: { url: wp.proxy },

--- a/src/Plugin/antiMessageModeration.js
+++ b/src/Plugin/antiMessageModeration.js
@@ -80,7 +80,13 @@ function createAntiMessageModeration({
 
     plugin.handleModeration = async function handleModeration(sock, m, mek) {
         try {
-            if (!m.isGroup || m.key?.fromMe || !detector(mek?.message || m.message || {})) return false;
+            const detectionPayload = {
+                raw: mek?.message || {},
+                message: m.message || {},
+                msg: m.msg || {},
+                serialized: m
+            };
+            if (!m.isGroup || m.key?.fromMe || !detector(detectionPayload)) return false;
             const config = readJson(dbPath)[m.chat];
             if (!config?.enabled) return false;
 
@@ -116,7 +122,7 @@ function createAntiMessageModeration({
             };
             const removeMessage = deleteMessage
                 ? () => deleteMessage(sock, m, mek, removalContext)
-                : () => sock.sendMessage(m.chat, { delete: m.key });
+                : () => sock.sendMessage(m.chat, { delete: mek?.key || m.key });
             try {
                 await removeMessage();
             } catch (error) {

--- a/src/Plugin/deployButtonRouter.js
+++ b/src/Plugin/deployButtonRouter.js
@@ -14,7 +14,6 @@ const DEPLOY_BUTTON_COMMANDS = new Map([
     ['help', '.deploy help'],
     ['tutorials', '.deploy tutorials'],
     ['back to menu', '.deploy menu'],
-    ['menu', '.deploy menu']
 ]);
 
 const normalizeDeployButton = value => {

--- a/tests/deploy-button-router.test.js
+++ b/tests/deploy-button-router.test.js
@@ -43,5 +43,7 @@ test('normalizes callback IDs and preserves unrelated text', () => {
     assert.equal(normalizeDeployButton('deploy:step3'), '.deploy step3');
     assert.equal(normalizeDeployButton('.deploy step4'), '.deploy step4');
     assert.equal(normalizeDeployButton('hello world'), null);
+    assert.equal(normalizeDeployButton('Menu'), null);
+    assert.equal(normalizeDeployButton('/menu'), null);
     assert.equal(normalizeDeployButton('Step 9 · Other'), null);
 });

--- a/tests/moderation-and-vv.test.js
+++ b/tests/moderation-and-vv.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { isForwardedMessage } = require('../src/Commands/Admin/antiforward');
+const vv = require('../src/Commands/Converter/view-once');
+
+test('AntiForward detects forwarding metadata in every message container', () => {
+  assert.equal(isForwardedMessage({ raw: { extendedTextMessage: { contextInfo: { isForwarded: true } } } }), true);
+  assert.equal(isForwardedMessage({ msg: { contextInfo: { forwardingScore: 2 } } }), true);
+  assert.equal(isForwardedMessage({ message: { conversation: 'ordinary text' } }), false);
+});
+
+test('view-once module exposes the automatic forwarding hook', () => {
+  assert.equal(typeof vv.handleAutoVV, 'function');
+  assert.ok(vv.alias.includes('autovv'));
+});
+
+test('wallpaper command loads without an undefined prefix reference', () => {
+  const wallpaper = require('../src/Commands/Search/wp');
+  assert.equal(wallpaper.usage, '.wallpaper <query>');
+});


### PR DESCRIPTION
## Summary
- fix wallpaper command loading and supported media-card fallback
- route raw message events into AntiForward and improve forwarded metadata detection
- make vvp privately deliver media with reaction-only acknowledgement
- add chat-scoped /autovv on|off|status for automatic DM forwarding

## Validation
- focused Node test suite: 11/11 passing
- edited JavaScript files pass node --check

Generated runtime database files are intentionally excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a group settings command showing moderation statuses, configured actions, and moderators.
  * Added automatic handling and private delivery of view-once media, with `autovv on`, `off`, and `status` controls.
  * Improved quoted-message support across forwarded, ephemeral, and view-once content.

* **Bug Fixes**
  * Fixed AntiLink, AntiGM, warning, wallpaper, and settings command responses.
  * Corrected temporary-kick duration handling and quoted-message deletion for warnings.
  * Improved moderation detection and wallpaper result delivery reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->