### PR TITLE
fix: anti statuses wallpaper fallback and settings mentions

### DIFF
--- a/?.js
+++ b/?.js
@@ -580,7 +580,7 @@ try {
             try { await require('./src/Commands/Admin/antigroupstatus.js').handleAntiGroupStatus?.(sock, m, mek); } catch (err) { console.error('[ANTIGROUPSTATUS ERROR]', err.message); }
             try { await require('./src/Commands/Admin/antibot.js').handleAntiBot?.(sock, m, mek); } catch (err) { console.error('[ANTIBOT ERROR]', err.message); }
             try { await require('./src/Commands/Admin/antiforward.js').handleAntiForward?.(sock, m, mek); } catch (err) { console.error('[ANTIFORWARD ERROR]', err.message); }
-            try { await require('./src/Commands/Admin/antilink.js').handleAntiLink?.(sock, m); } catch (err) { console.error('[ANTILINK ERROR]', err.message); }
+            try { await require('./src/Commands/Admin/antilink.js').handleAntiLink?.(sock, m, mek); } catch (err) { console.error('[ANTILINK ERROR]', err.message); }
             try { await require('./src/Commands/Converter/view-once.js').handleAutoVV?.(sock, m, mek); } catch (err) { console.error('[AUTOVV ERROR]', err.message); }
             try { await require('./src/Commands/Converter/vvcmd.js').handleVVReply?.(sock, m); } catch (err) { console.error('[VV ERROR]', err.message); }
 

--- a/src/Commands/Admin/antilink.js
+++ b/src/Commands/Admin/antilink.js
@@ -281,7 +281,7 @@ module.exports = {
 };
 
 // ── Message Handler ──────────────────────────────────────────────
-module.exports.handleAntiLink = async function(sock, m) {
+module.exports.handleAntiLink = async function(sock, m, mek) {
     try {
         if (!m.isGroup) return;
         if (m.key?.fromMe) return;
@@ -294,7 +294,11 @@ module.exports.handleAntiLink = async function(sock, m) {
         if (!cfg.enabled) return;
 
         // ── Extract text from ALL message types + extendedTextMessage fix ──
-        const msg = m.message || {};
+        const msg = {
+            ...(mek?.message || {}),
+            ...(m.message || {}),
+            ...(m.msg || {})
+        };
 
         const parts = [
             m.text,
@@ -339,7 +343,7 @@ module.exports.handleAntiLink = async function(sock, m) {
         const action = cfg.action || 'delete';
 
         // Delete the message FIRST for all actions
-        await sock.sendMessage(group, { delete: m.key }).catch(() => {});
+        await sock.sendMessage(group, { delete: mek?.key || m.key }).catch(() => {});
 
         if (action === 'delete') {
             await sock.sendMessage(group, {

--- a/src/Commands/Admin/antispam.js
+++ b/src/Commands/Admin/antispam.js
@@ -59,7 +59,7 @@ module.exports = {
 
         const sub = args[0]?.toLowerCase();
 
-        if (!sub) {
+        if (!sub || sub === 'status') {
             const cfg = db[group];
             let actionDisplay;
             if (cfg.action === 'delete') actionDisplay = ' ꙰⊕ DELETE';

--- a/src/Commands/Admin/antitag.js
+++ b/src/Commands/Admin/antitag.js
@@ -82,7 +82,7 @@ module.exports = {
 
         const sub = args[0]?.toLowerCase();
 
-        if (!sub) {
+        if (!sub || sub === 'status') {
             const cfg = db[group];
             let actionDisplay;
             if (cfg.action === 'delete') actionDisplay = ' ꙰⊕ DELETE';

--- a/src/Commands/Admin/antiword.js
+++ b/src/Commands/Admin/antiword.js
@@ -59,7 +59,7 @@ module.exports = {
 
         const sub = args[0]?.toLowerCase();
 
-        if (!sub) {
+        if (!sub || sub === 'status') {
             const cfg = db[group];
             const wordList = cfg.words.length 
                 ? cfg.words.map(w => `❏ ${w}`).join('\n')

--- a/src/Commands/Admin/settings.js
+++ b/src/Commands/Admin/settings.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { resolvePhoneJidWithMetadata } = require('../../Plugin/identityUtils');
 
 const readGroupConfig = name => {
     try {
@@ -25,13 +26,17 @@ module.exports = {
         const metadata = await sock.groupMetadata(m.chat).catch(() => null);
         if (!metadata) return reply('Unable to read group settings right now.');
 
-        const moderators = (metadata.participants || [])
-            .filter(participant => participant.admin === 'admin' || participant.admin === 'superadmin')
-            .map(participant => {
-                const jid = participant.id || participant.jid || '';
-                const role = participant.admin === 'superadmin' ? 'Owner' : 'Moderator';
-                return `• @${jid.split('@')[0]} — ${role}`;
-            });
+        const moderatorRecords = (metadata.participants || [])
+            .filter(participant => participant.admin === 'admin' || participant.admin === 'superadmin');
+        const resolvedModerators = await Promise.all(moderatorRecords.map(async participant => {
+            const candidates = [participant.phoneNumber, participant.jid, participant.id, participant.lid].filter(Boolean);
+            const jid = await resolvePhoneJidWithMetadata(sock, m.chat, candidates)
+                || candidates.find(value => String(value).endsWith('@s.whatsapp.net'))
+                || candidates[0] || '';
+            const role = participant.admin === 'superadmin' ? 'Owner' : 'Moderator';
+            return { jid: String(jid), role };
+        }));
+        const moderators = resolvedModerators.map(({ jid, role }) => `• @${jid.split('@')[0]} — ${role}`);
 
         const antiLink = readGroupConfig('antilink.json');
         const antiGm = readGroupConfig('antigm.json');
@@ -39,10 +44,7 @@ module.exports = {
         const antiForward = readGroupConfig('antiforward.json');
         const antiGroupStatus = readGroupConfig('antigroupstatus.json');
 
-        const mentions = (metadata.participants || [])
-            .filter(participant => participant.admin === 'admin' || participant.admin === 'superadmin')
-            .map(participant => participant.id || participant.jid)
-            .filter(Boolean);
+        const mentions = resolvedModerators.map(({ jid }) => jid).filter(jid => jid.endsWith('@s.whatsapp.net'));
 
         return reply(
             `⚙️ *Group Settings*\n\n` +

--- a/src/Commands/Search/wp.js
+++ b/src/Commands/Search/wp.js
@@ -2,10 +2,45 @@ const axios = require('axios');
 const config = require('../../../settings/config');
 
 const BOT_NAME = config.botname || process.env.BOTNAME || 'CRYSNOVA';
+const PRIMARY_API = 'https://wallpaper.crysnovax.link/api/search';
+const FALLBACK_API = 'https://wallhaven.cc/api/v1/search';
+
+function normalizeResults(data) {
+    const raw = Array.isArray(data) ? data : (data?.results || data?.data || data?.wallpapers || []);
+    return raw.map(item => ({
+        ...item,
+        proxy: item.proxy || item.path || item.thumbs?.original || item.thumbs?.large || item.url
+    })).filter(item => item.proxy);
+}
+
+async function searchWallpapers(query) {
+    try {
+        const response = await axios.get(PRIMARY_API, {
+            params: { query },
+            timeout: 20000,
+            validateStatus: () => true
+        });
+        if (response.status < 200 || response.status >= 300 || response.data?.status === false) {
+            throw new Error(response.data?.details || response.data?.error || `Wallpaper API HTTP ${response.status}`);
+        }
+        const results = normalizeResults(response.data);
+        if (results.length) return { results, source: 'CRYSNOVA Wallpaper API' };
+        throw new Error('CRYSNOVA Wallpaper API returned no results');
+    } catch (primaryError) {
+        console.warn('[WALLPAPER] Primary API unavailable:', primaryError.message);
+        const response = await axios.get(FALLBACK_API, {
+            params: { q: query, sorting: 'relevance', page: 1 },
+            timeout: 20000
+        });
+        const results = normalizeResults(response.data);
+        if (!results.length) throw new Error('No wallpapers returned by either provider');
+        return { results, source: 'Wallhaven fallback' };
+    }
+}
 
 module.exports = {
     name: 'wallpaper',
-    alias: ['wlp', 'wall',],
+    alias: ['wlp', 'wall'],
     desc: 'Search for beautiful wallpapers',
     category: 'Search',
     usage: '.wallpaper <query>',
@@ -16,67 +51,44 @@ module.exports = {
 
         try {
             await sock.sendMessage(m.chat, { react: { text: '🖼️', key: m.key } });
-            
-            const res = await axios.get(`https://wallpaper.crysnovax.link/api/search?query=${encodeURIComponent(query)}`);
-            const data = res.data;
-            const results = Array.isArray(data) ? data : (data?.results || data?.data || data?.wallpapers);
-
-            if (!Array.isArray(results) || results.length === 0) {
-                return reply(`✘ No wallpapers found for "${query}"`);
-            }
-
-            // Build interactive carousel cards (max 10 cards)
+            const { results, source } = await searchWallpapers(query);
             const cards = results.slice(0, 10).map(wp => ({
                 image: { url: wp.proxy },
                 caption: `🖼️ *Wallpaper*\n🔍 ${query}`,
-                footer: `⚉ ${BOT_NAME} Vault`,
-                nativeFlow: [{
-                    text: '📥 Download',
-                    url: wp.proxy
-                }, {
-                    text: '📋 Copy URL',
-                    copy: wp.proxy
-                }]
+                footer: `⚉ ${BOT_NAME} Vault · ${source}`,
+                nativeFlow: [
+                    { text: '📥 Download', url: wp.proxy },
+                    { text: '📋 Copy URL', copy: wp.proxy }
+                ]
             }));
 
-            // Generic sendMessage does not understand card arrays. Prefer the
-            // fork's rich-grid helper, then fall back to ordinary images.
             if (typeof sock.sendRichButtonGrid === 'function') {
                 await sock.sendRichButtonGrid(m.chat, {
                     text: `🖼️ *WALLPAPER SEARCH: ${query}*`,
-                    footer: `Found ${results.length} results`,
+                    footer: `Found ${results.length} results · ${source}`,
                     cards
                 }, { quoted: m });
             } else if (typeof sock.sendInteractiveCarousel === 'function') {
                 await sock.sendInteractiveCarousel(m.chat, {
                     text: `🖼️ *WALLPAPER SEARCH: ${query}*`,
-                    footer: `Found ${results.length} results`,
+                    footer: `Found ${results.length} results · ${source}`,
                     cards
                 }, { quoted: m });
             } else {
-                throw new Error('No supported interactive wallpaper sender');
-            }
-
-            await sock.sendMessage(m.chat, { react: { text: '✨', key: m.key } });
-            
-        } catch (err) {
-            console.error('[WALLPAPER]', err.message);
-            
-            // Fallback to simple image messages if carousel fails
-            try {
-                const res = await axios.get(`https://wallpaper.crysnovax.link/api/search?query=${encodeURIComponent(query)}`);
-                const fallbackData = res.data;
-                const results = Array.isArray(fallbackData) ? fallbackData : (fallbackData?.results || fallbackData?.data || fallbackData?.wallpapers || []);
                 for (const wp of results.slice(0, 5)) {
                     await sock.sendMessage(m.chat, {
                         image: { url: wp.proxy },
                         caption: `🖼️ *Wallpaper: ${query}*\n\n_⚉ ${BOT_NAME} Vault_`
                     }, { quoted: m });
-                    await new Promise(r => setTimeout(r, 300));
                 }
-            } catch (fallbackErr) {
-                reply('✘ Search failed entirely.');
             }
+            await sock.sendMessage(m.chat, { react: { text: '✨', key: m.key } });
+        } catch (error) {
+            console.error('[WALLPAPER]', error.stack || error.message);
+            await reply(`✘ Wallpaper search failed: ${error.message}`);
         }
     }
 };
+
+module.exports.normalizeResults = normalizeResults;
+module.exports.searchWallpapers = searchWallpapers;

--- a/src/Plugin/antiMessageModeration.js
+++ b/src/Plugin/antiMessageModeration.js
@@ -49,7 +49,7 @@ function createAntiMessageModeration({
             const config = ensureConfig(db, m.chat);
             const subcommand = args[0]?.toLowerCase();
 
-            if (!subcommand) {
+            if (!subcommand || subcommand === 'status') {
                 const action = config.action === 'warn' ? 'WARN (3x → KICK)' : config.action.toUpperCase();
                 return reply(`*${label} Settings*\n\n• Status : ${config.enabled ? 'ON' : 'OFF'}\n• Action : ${action}\n\nCommands:\n• .${command} on / off\n• .${command} delete / warn / kick\n• .${command} resetwarn @user`);
             }

--- a/src/Plugin/crysMsg.js
+++ b/src/Plugin/crysMsg.js
@@ -306,7 +306,7 @@ const handleMessage = async (sock, m, store) => {
                 isOwnerAdmin;
         }
 
-        const reply = (txt) => sock.sendMessage(m.chat, { text: txt }, { quoted: m });
+        const reply = (txt, options = {}) => sock.sendMessage(m.chat, { text: txt, ...options }, { quoted: m });
 
         // MODIFIED: Allow 'appeal' command for everyone even in private mode
         const isPublicCommand = cmdName === 'appeal';


### PR DESCRIPTION
## Summary
- make every configurable anti command accept an explicit status subcommand
- use Wallhaven fallback when the CRYSNOVA wallpaper backend returns upstream 525
- pass raw events and keys through AntiLink moderation
- resolve moderator LIDs to phone JIDs for actual WhatsApp mentions
- preserve mention options in command replies

## Validation
- focused tests: 11/11 passing
- edited JavaScript files pass node --check

Runtime database artifacts are excluded.