### PR TITLE
fix: make wallpaper carousel delivery reliable

### DIFF
--- a/src/Commands/Converter/view-once.js
+++ b/src/Commands/Converter/view-once.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { downloadContentFromMessage } = require('@crysnovax/baileys');
+const { resolvePhoneJidWithMetadata } = require('../../Plugin/identityUtils');
 
 const DATA_FILE = path.join(__dirname, '../../../database/vv-reactions.json');
 const AUTOVV_FILE = path.join(__dirname, '../../../database/autovv.json');
@@ -220,7 +221,17 @@ module.exports.handleAutoVV = async function handleAutoVV(sock, m, mek) {
     const content = unwrapViewOnce(mek?.message || m?.message);
     const media = await downloadMedia(content);
     if (!media) return false;
-    const recipient = m?.sender || mek?.key?.participant || chat;
+    const senderCandidates = [
+      m?.sender,
+      mek?.key?.participant,
+      mek?.key?.participantAlt,
+      m?.key?.participant,
+      m?.key?.participantAlt
+    ].filter(Boolean);
+    const recipient = await resolvePhoneJidWithMetadata(sock, chat, senderCandidates)
+      || senderCandidates.find(jid => String(jid).endsWith('@s.whatsapp.net'))
+      || senderCandidates[0];
+    if (!recipient) return false;
     const sendType = media.type.replace('Message', '').toLowerCase();
     await sock.sendMessage(recipient, { [sendType]: media.buffer });
     await sock.sendMessage(chat, { react: { text: '👁️', key: m?.key || mek?.key } }).catch(() => {});

--- a/src/Commands/Converter/view-once.js
+++ b/src/Commands/Converter/view-once.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 const { downloadContentFromMessage } = require('@crysnovax/baileys');
-const { resolvePhoneJidWithMetadata } = require('../../Plugin/identityUtils');
 
 const DATA_FILE = path.join(__dirname, '../../../database/vv-reactions.json');
 const AUTOVV_FILE = path.join(__dirname, '../../../database/autovv.json');
@@ -221,17 +220,7 @@ module.exports.handleAutoVV = async function handleAutoVV(sock, m, mek) {
     const content = unwrapViewOnce(mek?.message || m?.message);
     const media = await downloadMedia(content);
     if (!media) return false;
-    const senderCandidates = [
-      m?.sender,
-      mek?.key?.participant,
-      mek?.key?.participantAlt,
-      m?.key?.participant,
-      m?.key?.participantAlt
-    ].filter(Boolean);
-    const recipient = await resolvePhoneJidWithMetadata(sock, chat, senderCandidates)
-      || senderCandidates.find(jid => String(jid).endsWith('@s.whatsapp.net'))
-      || senderCandidates[0];
-    if (!recipient) return false;
+    const recipient = m?.sender || mek?.key?.participant || chat;
     const sendType = media.type.replace('Message', '').toLowerCase();
     await sock.sendMessage(recipient, { [sendType]: media.buffer });
     await sock.sendMessage(chat, { react: { text: '👁️', key: m?.key || mek?.key } }).catch(() => {});

--- a/src/Commands/Search/WP.js
+++ b/src/Commands/Search/WP.js
@@ -65,24 +65,24 @@ module.exports = {
             let delivered = false;
             if (typeof sock.sendRichButtonGrid === 'function') {
                 try {
-                    await sock.sendRichButtonGrid(m.chat, {
+                    const sent = await sock.sendRichButtonGrid(m.chat, {
                         text: `🖼️ *WALLPAPER SEARCH: ${query}*`,
                         footer: `Found ${results.length} results · ${source}`,
                         cards
                     }, { quoted: m });
-                    delivered = true;
+                    delivered = Boolean(sent?.key?.id || sent?.message?.key?.id || sent?.id);
                 } catch (error) {
                     console.warn('[WALLPAPER] Rich-grid delivery failed; using image fallback:', error.message);
                 }
             }
             if (!delivered && typeof sock.sendInteractiveCarousel === 'function') {
                 try {
-                    await sock.sendInteractiveCarousel(m.chat, {
+                    const sent = await sock.sendInteractiveCarousel(m.chat, {
                         text: `🖼️ *WALLPAPER SEARCH: ${query}*`,
                         footer: `Found ${results.length} results · ${source}`,
                         cards
                     }, { quoted: m });
-                    delivered = true;
+                    delivered = Boolean(sent?.key?.id || sent?.message?.key?.id || sent?.id);
                 } catch (error) {
                     console.warn('[WALLPAPER] Carousel delivery failed; using image fallback:', error.message);
                 }


### PR DESCRIPTION
## Summary
- verify rich-grid and carousel helpers actually return a message key
- fall back to direct image messages when interactive delivery is rejected or silent
- keep the existing CRYSNOVA API and Wallhaven fallback search flow

## Validation
- wallpaper command syntax check passes
- existing focused tests pass
- carousel delivery fallback was exercised with a simulated silent/failed helper

This PR contains the carousel delivery change only; AutoVV and invisible-marker behavior are excluded.