### PR TITLE
fix: make PLOGME opt-in and music audio shareable

### DIFF
--- a/?.js
+++ b/?.js
@@ -578,7 +578,7 @@ try {
             // messages; command messages remain handled by handleMessage below.
             try { await require('./src/Commands/Admin/antigm.js').handleAntiGM?.(sock, m, mek); } catch (err) { console.error('[ANTIGM ERROR]', err.message); }
             try { await require('./src/Commands/Admin/antigroupstatus.js').handleAntiGroupStatus?.(sock, m, mek); } catch (err) { console.error('[ANTIGROUPSTATUS ERROR]', err.message); }
-            try { await require('./src/Commands/Admin/antibot.js').handleAntiBot?.(sock, m, mek); } catch (err) { console.error('[ANTIBOT ERROR]', err.message); }
+            try { await require('./src/Commands/Admin/antibot.js').handleAntiBot?.(sock, m, mek); } catch (err) { console.error('[ANTIBOT ERROR]', err?.stack || err?.message || String(err)); }
             try { await require('./src/Commands/Admin/antiforward.js').handleAntiForward?.(sock, m, mek); } catch (err) { console.error('[ANTIFORWARD ERROR]', err.message); }
             try { await require('./src/Commands/Admin/antilink.js').handleAntiLink?.(sock, m, mek); } catch (err) { console.error('[ANTILINK ERROR]', err.message); }
             try { await require('./src/Commands/Converter/view-once.js').handleAutoVV?.(sock, m, mek); } catch (err) { console.error('[AUTOVV ERROR]', err.message); }

--- a/src/Commands/AI/mg.js
+++ b/src/Commands/AI/mg.js
@@ -79,25 +79,11 @@ module.exports = {
       const result = await generateMusic(input);
       const audio = await fetchAudio(result.url);
       const title = String(result.title || input.prompt).slice(0, 80);
-      const tags = result.tags ? `\nTags: ${result.tags}` : '';
-      const duration = result.duration ? `\nDuration: ${result.duration}s` : '';
-
       await sock.sendMessage(m.chat, {
         audio,
         mimetype: 'audio/mpeg',
         ptt: false,
-        fileName: `${title.replace(/[^a-z0-9._ -]/gi, '').trim() || 'cody-music'}.mp3`,
-        contextInfo: {
-          externalAdReply: {
-            title,
-            body: `CODY Music Generator${tags}${duration}`,
-            mediaType: 2,
-            thumbnailUrl: result.thumbnail || undefined,
-            sourceUrl: result.url,
-            renderLargerThumbnail: true,
-            showAdAttribution: false
-          }
-        }
+        fileName: `${title.replace(/[^a-z0-9._ -]/gi, '').trim() || 'cody-music'}.mp3`
       }, { quoted: m });
 
       if (progress?.key) await sock.sendMessage(m.chat, { delete: progress.key }).catch(() => {});

--- a/src/Commands/Core/plogme.js
+++ b/src/Commands/Core/plogme.js
@@ -2186,14 +2186,11 @@ async function execute(sock, m, opts) {
         // auto-replies after an explicit `.plogme on` (or `.plogme on all` for
         // DM-wide). An explicit `.plogme off` is honored and stays off.
         // (@crysnovax—FIX12-08-26)
+        // PLOGME is strictly opt-in. A chat or global-DM mode must be
+        // explicitly enabled with `.plogme on` or `.plogme on all`.
+        // Environment variables never implicitly enable auto-replies.
         let on = isEnabled(m.chat);
-        if (!m.isGroup) {
-            if (!on && isGlobalPrivateEnabled()) on = true;
-            // PLOGME is OFF by default — a chat only auto-replies after an
-            // explicit ".plogme on" (or PLOGME_DM=true is set). No implicit
-            // always-on behavior. (@crysnovax—FIX12-08-26)
-            if (!on && getVar('PLOGME_DM', false) === true && !hasExplicitToggle(m.chat)) on = true;
-        }
+        if (!m.isGroup && !on && isGlobalPrivateEnabled()) on = true;
         if (!on) return false;
 
         // NEVER respond to messages that look like bot commands — anything


### PR DESCRIPTION
## Summary
- keep PLOGME auto-replies off unless explicitly enabled per chat or globally
- send musicgen output as a plain shareable MP3 without play-style preview metadata
- harden AntiBot hook error logging in the active dispatcher
- preserve the intentional invisible-marker behavior

PR #52 was already merged; this PR contains the post-merge follow-up commit.