### PR TITLE
fix: update Baileys for WhatsApp handshake compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",
-        "@crysnovax/baileys": "2.7.12",
+        "@crysnovax/baileys": "2.7.14",
         "@distube/ytdl-core": "^4.16.12",
         "@faker-js/faker": "^10.3.0",
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@crysnovax/baileys": {
-      "version": "2.7.12",
-      "resolved": "https://registry.npmjs.org/@crysnovax/baileys/-/baileys-2.7.12.tgz",
-      "integrity": "sha512-tdW+L4mdKpJtpu4xQsdDRuIPNspYwaBwqP5MwxN8cJ+CIrLaA0lQ8Op2f7QNLZmkt8cP6QpJByZr5SSNgntXpQ==",
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/@crysnovax/baileys/-/baileys-2.7.14.tgz",
+      "integrity": "sha512-Gst6T1ANkwEBzU7CgNJefgvES2bBtVclC5D5LYGU+uz1rujrG3NlCDd7sqU3jlYE8npI+0Zj03xdu5htPuY/BQ==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@adiwajshing/keyed-db": "^0.2.4",
-    "@crysnovax/baileys": "2.7.12",
+    "@crysnovax/baileys": "2.7.14",
     "@distube/ytdl-core": "^4.16.12",
     "@faker-js/faker": "^10.3.0",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the messaging integration dependency to version 2.7.14 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->