### PR TITLE
feat: replace CODY bancheck with Baileys ban status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",
-        "@crysnovax/baileys": "2.7.14",
+        "@crysnovax/baileys": "2.7.15",
         "@distube/ytdl-core": "^4.16.12",
         "@faker-js/faker": "^10.3.0",
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@crysnovax/baileys": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/@crysnovax/baileys/-/baileys-2.7.14.tgz",
-      "integrity": "sha512-Gst6T1ANkwEBzU7CgNJefgvES2bBtVclC5D5LYGU+uz1rujrG3NlCDd7sqU3jlYE8npI+0Zj03xdu5htPuY/BQ==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/@crysnovax/baileys/-/baileys-2.7.15.tgz",
+      "integrity": "sha512-wJI2YT2tKcqIY6qoFvnY7UZzyDvzZdmGOtIR4FmR3H0MoomXOW7j0mW/fLOfppEZBE92vlbco14mcfYWzrBv0A==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@adiwajshing/keyed-db": "^0.2.4",
-    "@crysnovax/baileys": "2.7.14",
+    "@crysnovax/baileys": "2.7.15",
     "@distube/ytdl-core": "^4.16.12",
     "@faker-js/faker": "^10.3.0",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",

--- a/src/Commands/Owner/bancheck.js
+++ b/src/Commands/Owner/bancheck.js
@@ -1,5 +1,24 @@
+const { checkStatusWA } = require('@crysnovax/baileys');
+
 function normalizeNumber(value = '') {
     return String(value).replace(/[^0-9]/g, '');
+}
+
+function formatBanResult(result) {
+    const lines = [
+        `Number: ${result.number}`,
+        `Status: ${result.status}`,
+        `Ban detected: ${result.isBanned ? 'YES' : 'NO'}`
+    ];
+    if (result.banInfo) {
+        lines.push(`Ban type: ${result.banInfo.banType || 'unknown'}`);
+        lines.push(`Can appeal: ${result.banInfo.canAppeal ? 'yes' : 'no'}`);
+        if (result.banInfo.appealStatus) lines.push(`Appeal status: ${result.banInfo.appealStatus}`);
+    }
+    if (result.isNeedOfficialWa) lines.push('Action: use the official WhatsApp application.');
+    if (result.status === 'unknown') lines.push('Note: WhatsApp returned an unrecognized response; this is inconclusive, not a ban confirmation.');
+    else lines.push('Source: WhatsApp ban-status endpoint via @crysnovax/baileys.');
+    return lines.join('\n');
 }
 
 module.exports = {
@@ -7,27 +26,21 @@ module.exports = {
     alias: ['checkban', 'numbercheck'],
     category: 'Owner',
     ownerOnly: true,
-    desc: 'Check WhatsApp registration/reachability without claiming an official ban verdict',
-    execute: async (sock, m, { args = [], reply }) => {
+    desc: 'Check WhatsApp ban status using the Baileys ban-status endpoint',
+    execute: async (_sock, m, { args = [], reply }) => {
         const number = normalizeNumber(args[0] || m?.sender || '');
         if (!number) return reply('Usage: .bancheck <country-code-and-number>');
-        if (typeof sock.onWhatsApp !== 'function') {
-            return reply('This Baileys runtime does not expose onWhatsApp, so reachability cannot be checked.');
-        }
 
         try {
-            const result = await sock.onWhatsApp(`${number}@s.whatsapp.net`);
-            const entry = Array.isArray(result) ? result[0] : result;
-            const jid = entry?.jid || `${number}@s.whatsapp.net`;
-            const registered = entry?.exists === true || entry?.status === 200;
-            return reply([
-                `Number: ${number}`,
-                `Status: ${registered ? 'registered/reachable' : 'not confirmed as registered'}`,
-                'Note: this is a registration/reachability check, not an official account-ban verdict.'
-            ].join('\n'));
+            if (typeof checkStatusWA !== 'function') {
+                return reply('This Baileys version does not expose the ban-status checker. Update to @crysnovax/baileys@2.7.15.');
+            }
+            const result = await checkStatusWA(number);
+            return reply(formatBanResult(result));
         } catch (error) {
-            return reply(`Ban check could not complete for ${number}: ${error?.message || error}\nNote: this is not an official account-ban verdict.`);
+            return reply(`Ban check could not complete for ${number}: ${error?.message || error}`);
         }
     },
+    formatBanResult,
     normalizeNumber
 };

--- a/tests/status-and-ban-commands.test.js
+++ b/tests/status-and-ban-commands.test.js
@@ -8,7 +8,14 @@ Module._load = function patchedLoad(request, parent, isMain) {
         return {
             downloadContentFromMessage: async function* () {
                 yield Buffer.from('unused');
-            }
+            },
+            checkStatusWA: async number => ({
+                number: `+${number}`,
+                status: 'active',
+                isBanned: false,
+                isNeedOfficialWa: false,
+                banInfo: null
+            })
         };
     }
     return originalLoad.call(this, request, parent, isMain);
@@ -70,17 +77,15 @@ test('groupstatus sends audio through sendGroupStatus with selectable background
     assert.match(replies[0], /Group status posted/i);
 });
 
-test('bancheck reports registration status using onWhatsApp', async () => {
+test('bancheck reports Baileys ban status using the number directly', async () => {
     const replies = [];
-    const sock = {
-        onWhatsApp: async jid => [{ jid, exists: true }]
-    };
 
-    await bancheck.execute(sock, { chat: '12345@s.whatsapp.net' }, {
-        args: ['15550001111'],
+    await bancheck.execute({}, { chat: '12345@s.whatsapp.net' }, {
+        args: ['+1 (555) 000-1111'],
         reply: async value => replies.push(value)
     });
 
-    assert.match(replies[0], /registered/i);
-    assert.match(replies[0], /not an official account-ban verdict/i);
+    assert.match(replies[0], /Status: active/i);
+    assert.match(replies[0], /Ban detected: NO/i);
+    assert.match(replies[0], /ban-status endpoint/i);
 });


### PR DESCRIPTION
Replaces CODY’s registration-only onWhatsApp check with @crysnovax/baileys checkStatusWA.

The command now reports active, banned, blocked, rate-limited, not-registered, and unknown classifications without treating unknown as a ban. It preserves owner-only usage and digits-only international input.

Validation: focused status-and-ban-commands tests pass 3/3; ban-checker logic is covered by the Baileys suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Baileys-based WhatsApp ban-status checking.
  * Ban-check results now display ban status, details, appeal information, official-app requirements, and endpoint errors.
  * Added a clear notice when ban checking is unavailable.

* **Bug Fixes**
  * Improved phone-number formatting and status reporting for ban checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->