### PR TITLE
fix: point auto-update commands to CODY

### DIFF
--- a/src/Commands/System/format.js
+++ b/src/Commands/System/format.js
@@ -4,7 +4,7 @@ const axios = require('axios');
 const AdmZip = require('adm-zip');
 
 const CONFIG = {
-    repo: 'crysnovax/CRYSNOVA_AI',
+    repo: 'crysnovax/CODY',
     branch: 'main',
     tempDir: './.format_temp',
     backupDir: './.format_backup',

--- a/src/Plugin/updater.js
+++ b/src/Plugin/updater.js
@@ -4,7 +4,7 @@ const axios = require('axios');
 const AdmZip = require('adm-zip');
 
 const CONFIG = {
-    repo: 'crysnovax/CRYSNOVA_AI',
+    repo: 'crysnovax/CODY',
     branch: 'main',
     backupDir: './.update_backup',
     tempDir: './.update_temp',


### PR DESCRIPTION
Corrects CODY’s update repository target.

The standard startup auto-updater and the format/clean-install command were incorrectly downloading crysnovax/CRYSNOVA_AI. Both now download crysnovax/CODY from main. The premium update command was already configured correctly and remains unchanged.

Validation: syntax checks pass for all update commands, all three repository targets resolve to crysnovax/CODY, focused status-and-ban-command tests pass 3/3, and git diff --check passes.