### PR TITLE
feat: add safe bancheck diagnostics

### DIFF
--- a/src/Commands/Owner/bancheck.js
+++ b/src/Commands/Owner/bancheck.js
@@ -18,6 +18,16 @@ function formatBanResult(result) {
     if (result.isNeedOfficialWa) lines.push('Action: use the official WhatsApp application.');
     if (result.status === 'unknown') lines.push('Note: WhatsApp returned an unrecognized response; this is inconclusive, not a ban confirmation.');
     else lines.push('Source: WhatsApp ban-status endpoint via @crysnovax/baileys.');
+    if (result.diagnostics) {
+        const d = result.diagnostics;
+        lines.push('', 'Diagnostics (safe metadata only):');
+        lines.push(`• HTTP status: ${d.httpStatus ?? 'unknown'}`);
+        lines.push(`• Response OK: ${d.ok ? 'yes' : 'no'}`);
+        lines.push(`• Content type: ${d.contentType || 'unknown'}`);
+        lines.push(`• Body keys: ${d.bodyKeys?.join(', ') || '(none)'}`);
+        lines.push(`• Data keys: ${d.dataKeys?.join(', ') || '(none)'}`);
+        lines.push(`• Signals: ${Object.entries(d.signals || {}).filter(([, value]) => value).map(([key]) => key).join(', ') || '(none)'}`);
+    }
     return lines.join('\n');
 }
 
@@ -28,14 +38,16 @@ module.exports = {
     ownerOnly: true,
     desc: 'Check WhatsApp ban status using the Baileys ban-status endpoint',
     execute: async (_sock, m, { args = [], reply }) => {
-        const number = normalizeNumber(args[0] || m?.sender || '');
-        if (!number) return reply('Usage: .bancheck <country-code-and-number>');
+        const diagnostic = args.some((arg) => /^(--)?debug$/i.test(String(arg)));
+        const numberArg = args.find((arg) => !/^(--)?debug$/i.test(String(arg)));
+        const number = normalizeNumber(numberArg || m?.sender || '');
+        if (!number) return reply(`Usage: .bancheck <country-code-and-number> [--debug]`);
 
         try {
             if (typeof checkStatusWA !== 'function') {
                 return reply('This Baileys version does not expose the ban-status checker. Update to @crysnovax/baileys@2.7.15.');
             }
-            const result = await checkStatusWA(number);
+            const result = await checkStatusWA(number, { diagnostic });
             return reply(formatBanResult(result));
         } catch (error) {
             return reply(`Ban check could not complete for ${number}: ${error?.message || error}`);

--- a/tests/status-and-ban-commands.test.js
+++ b/tests/status-and-ban-commands.test.js
@@ -3,19 +3,31 @@ const Module = require('node:module');
 const test = require('node:test');
 
 const originalLoad = Module._load;
+let lastBanOptions;
 Module._load = function patchedLoad(request, parent, isMain) {
     if (request === '@crysnovax/baileys') {
         return {
             downloadContentFromMessage: async function* () {
                 yield Buffer.from('unused');
             },
-            checkStatusWA: async number => ({
-                number: `+${number}`,
-                status: 'active',
-                isBanned: false,
-                isNeedOfficialWa: false,
-                banInfo: null
-            })
+            checkStatusWA: async (number, options = {}) => {
+                lastBanOptions = options;
+                return {
+                    number: `+${number}`,
+                    status: 'active',
+                    isBanned: false,
+                    isNeedOfficialWa: false,
+                    banInfo: null,
+                    diagnostics: options.diagnostic ? {
+                        httpStatus: 400,
+                        ok: false,
+                        contentType: 'application/json',
+                        bodyKeys: ['unexpected'],
+                        dataKeys: [],
+                        signals: { hasReason: false, hasError: false, hasStatus: false, hasAppealToken: false, hasBanFields: false }
+                    } : undefined
+                };
+            }
         };
     }
     return originalLoad.call(this, request, parent, isMain);
@@ -88,4 +100,19 @@ test('bancheck reports Baileys ban status using the number directly', async () =
     assert.match(replies[0], /Status: active/i);
     assert.match(replies[0], /Ban detected: NO/i);
     assert.match(replies[0], /ban-status endpoint/i);
+});
+
+test('bancheck debug mode returns safe diagnostics without raw response values', async () => {
+    const replies = [];
+
+    await bancheck.execute({}, { chat: '12345@s.whatsapp.net' }, {
+        args: ['2348077528901', '--debug'],
+        reply: async value => replies.push(value)
+    });
+
+    assert.equal(lastBanOptions.diagnostic, true);
+    assert.match(replies[0], /Diagnostics \(safe metadata only\)/i);
+    assert.match(replies[0], /HTTP status: 400/i);
+    assert.match(replies[0], /Body keys: unexpected/i);
+    assert.doesNotMatch(replies[0], /raw-response-value|appeal_token/i);
 });


### PR DESCRIPTION
Adds the owner-only `.bancheck <number> --debug` mode. It requests the new diagnostic option from @crysnovax/baileys and renders only HTTP status, content type, response key names, and boolean signal metadata. No raw response body, access token, appeal token, or credentials are printed.

This is coordinated with crysnovax/baileys PR #21, which adds the diagnostic API in version 2.7.16. The normal bancheck output remains unchanged.

Validation: CODY ban/status tests pass 4/4, syntax checks pass, and git diff --check passes.