### PR TITLE
feat: add owner richgen test command

### DIFF
--- a/src/Commands/Owner/richgen.js
+++ b/src/Commands/Owner/richgen.js
@@ -1,0 +1,88 @@
+const DEFAULT_VIDEO_URL = 'https://cdn.crysnovax.link/files/1786874387710-9a4780ff-706c-4fb0-85d5-d2becb101696.mp4';
+
+function option(args = [], name) {
+    const prefix = `--${name}=`;
+    const value = args.find(arg => String(arg).toLowerCase().startsWith(prefix));
+    return value ? String(value).slice(prefix.length) : undefined;
+}
+
+function hasFlag(args = [], value) {
+    return args.some(arg => String(arg).toLowerCase() === value);
+}
+
+function generationPayload(status, text, url, estimatedMs) {
+    return {
+        text,
+        mediaType: 'video',
+        status,
+        ...(url ? { url, mimeType: 'video/mp4', duration: 10 } : {}),
+        ...(estimatedMs ? { estimatedMs } : {})
+    };
+}
+
+module.exports = {
+    name: 'richgen',
+    alias: ['test-richgen', 'generationtest'],
+    category: 'Owner',
+    ownerOnly: true,
+    desc: 'Test native RichGen video generation progress and replacement',
+    execute: async (sock, m, context = {}) => {
+        const { args = [], reply, prefix = '.' } = context;
+        if (typeof sock.sendRichGeneration !== 'function' || typeof sock.updateRichGeneration !== 'function') {
+            return reply('This Baileys version does not expose RichGen. Update to @crysnovax/baileys@2.7.16 or later.');
+        }
+
+        const state = String(option(args, 'state') || 'both').toLowerCase();
+        const url = option(args, 'url') || DEFAULT_VIDEO_URL;
+        const delayMs = Math.max(0, Math.min(Number(option(args, 'delay') || 3000), 30000));
+        const quoted = m;
+
+        if (!['both', 'generating', 'ready', 'failed'].includes(state)) {
+            return reply(`Usage: ${prefix}richgen [--state=both|generating|ready|failed] [--delay=3000] [--url=https://...]`);
+        }
+
+        try {
+            if (state === 'ready' || state === 'failed') {
+                return reply(`Use ${prefix}richgen without --state=${state}; the command must send the GENERATING card first so it can replace it in place.`);
+            }
+
+            const generated = await sock.sendRichGeneration(
+                m.chat,
+                generationPayload('GENERATING', 'CRYSNOVA video generation in progress…', '', delayMs),
+                quoted
+            );
+            const ids = {
+                messageId: generated.messageId,
+                responseId: generated.responseId,
+                itemId: generated.itemId
+            };
+
+            if (state === 'generating') {
+                return reply(`RichGen GENERATING card sent.\nMessage ID: ${ids.messageId}\nResponse ID: ${ids.responseId}\nItem ID: ${ids.itemId}`);
+            }
+
+            await new Promise(resolve => setTimeout(resolve, delayMs));
+            const failed = hasFlag(args, '--failed');
+            const finalState = failed ? 'FAILED' : 'READY';
+            const updated = await sock.updateRichGeneration(
+                m.chat,
+                ids.messageId,
+                generationPayload(
+                    finalState,
+                    failed ? 'CRYSNOVA video generation failed.' : 'CRYSNOVA video generation complete.',
+                    failed ? '' : url
+                ),
+                { itemId: ids.itemId, responseId: ids.responseId }
+            );
+
+            return reply(`RichGen ${finalState} replacement sent in place.\nMessage ID: ${ids.messageId}\nResponse ID: ${updated.responseId || ids.responseId}\nItem ID: ${updated.itemId || ids.itemId}`);
+        } catch (error) {
+            return reply(`RichGen test failed: ${error?.message || error}`);
+        }
+    },
+    option,
+    generationPayload
+};
+
+// `--failed` is intentionally accepted as a standalone flag by hasFlag above.
+// The command remains owner-only and never invokes an external generation provider.

--- a/tests/richgen-command.test.js
+++ b/tests/richgen-command.test.js
@@ -1,0 +1,57 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const richgen = require('../src/Commands/Owner/richgen.js');
+
+function context(args, calls, replies) {
+    const sock = {
+        sendRichGeneration: async (jid, content, quoted) => {
+            calls.push({ type: 'send', jid, content, quoted });
+            return { messageId: 'message-1', responseId: 'response-1', itemId: 'item-1' };
+        },
+        updateRichGeneration: async (jid, targetId, content, options) => {
+            calls.push({ type: 'update', jid, targetId, content, options });
+            return { responseId: options.responseId, itemId: options.itemId };
+        }
+    };
+    return {
+        sock,
+        message: { chat: '12345@s.whatsapp.net', key: { id: 'quoted-1' } },
+        context: { args, prefix: '.', reply: async value => replies.push(value) }
+    };
+}
+
+test('richgen sends a native GENERATING card without replacement when requested', async () => {
+    const calls = [];
+    const replies = [];
+    const value = context(['--state=generating', '--delay=0'], calls, replies);
+
+    await richgen.execute(value.sock, value.message, value.context);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].type, 'send');
+    assert.equal(calls[0].content.mediaType, 'video');
+    assert.equal(calls[0].content.status, 'GENERATING');
+    assert.match(replies[0], /Message ID: message-1/);
+});
+
+test('richgen replaces the GENERATING card in place with READY', async () => {
+    const calls = [];
+    const replies = [];
+    const value = context(['--delay=0', '--url=https://example.com/video.mp4'], calls, replies);
+
+    await richgen.execute(value.sock, value.message, value.context);
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[1].type, 'update');
+    assert.equal(calls[1].targetId, 'message-1');
+    assert.equal(calls[1].content.status, 'READY');
+    assert.equal(calls[1].content.url, 'https://example.com/video.mp4');
+    assert.deepEqual(calls[1].options, { itemId: 'item-1', responseId: 'response-1' });
+    assert.match(replies[0], /READY replacement/);
+});
+
+test('richgen reports a helpful message when RichGen is unavailable', async () => {
+    const replies = [];
+    await richgen.execute({}, { chat: '12345@s.whatsapp.net' }, { args: [], reply: async value => replies.push(value) });
+    assert.match(replies[0], /@crysnovax\/baileys@2\.7\.16/);
+});


### PR DESCRIPTION
Adds the owner-only `.richgen` command for testing native video RichGen messages.

Default usage sends a GENERATING card, waits briefly, and replaces it in place with READY using the published Baileys 2.7.16 `sendRichGeneration` and `updateRichGeneration` helpers. `--state=generating` leaves the progress card in place, `--failed` tests the FAILED replacement, and `--url=` allows a custom video URL. No external AI provider is invoked.

Examples:
- `.richgen`
- `.richgen --state=generating`
- `.richgen --delay=5000 --url=https://example.com/video.mp4`
- `.richgen --failed`

Validation: RichGen and existing ban/status tests pass 7/7, syntax checks pass, and git diff --check passes. Unrelated runtime database files were excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an owner-only command for testing native RichGen video generation.
  - Supports configurable generation states, source URLs, and optional delays.
  - Displays progress with a generating status, then updates the message when generation is ready or fails.
  - Reports relevant message identifiers and provides clear feedback for unsupported capabilities, invalid options, and runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->