### PR TITLE
chore: update Baileys to 2.7.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",
-        "@crysnovax/baileys": "2.7.16",
+        "@crysnovax/baileys": "2.7.17",
         "@distube/ytdl-core": "^4.16.12",
         "@faker-js/faker": "^10.3.0",
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@crysnovax/baileys": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@crysnovax/baileys/-/baileys-2.7.16.tgz",
-      "integrity": "sha512-2oM70FMToBws941sEJjgxzA7lVF6WSdiYuQ85uw974U52u5GcYXocbkyF/wW4+VXKr7LQkezXfQIWG002LPY3Q==",
+      "version": "2.7.17",
+      "resolved": "https://registry.npmjs.org/@crysnovax/baileys/-/baileys-2.7.17.tgz",
+      "integrity": "sha512-q8k6kmlA7ZZbOKg+AczzFC5gcGHh3dg3ctn5y4KcGHORjbE16HapqGGmZMYCExNyZmvZNeCwM+7CXUpHf7EzTA==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@adiwajshing/keyed-db": "^0.2.4",
-    "@crysnovax/baileys": "2.7.16",
+    "@crysnovax/baileys": "2.7.17",
     "@distube/ytdl-core": "^4.16.12",
     "@faker-js/faker": "^10.3.0",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",


### PR DESCRIPTION
Updates CODY to the published @crysnovax/baileys@2.7.17 release, which fixes RichGen in-place type-14 replacement.

The fix is coordinated with crysnovax/baileys PR #22. CODY’s `.richgen` command and tests are already present in main.

Validation: clean npm ci with scripts disabled, installed Baileys version confirmed as 2.7.17, RichGen and ban/status tests pass 7/7, syntax checks pass, and git diff --check passes.

Unrelated runtime database files were excluded.