### PR TITLE
chore: update Baileys to 2.7.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",
-        "@crysnovax/baileys": "2.7.17",
+        "@crysnovax/baileys": "2.7.18",
         "@distube/ytdl-core": "^4.16.12",
         "@faker-js/faker": "^10.3.0",
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@crysnovax/baileys": {
-      "version": "2.7.17",
-      "resolved": "https://registry.npmjs.org/@crysnovax/baileys/-/baileys-2.7.17.tgz",
-      "integrity": "sha512-q8k6kmlA7ZZbOKg+AczzFC5gcGHh3dg3ctn5y4KcGHORjbE16HapqGGmZMYCExNyZmvZNeCwM+7CXUpHf7EzTA==",
+      "version": "2.7.18",
+      "resolved": "https://registry.npmjs.org/@crysnovax/baileys/-/baileys-2.7.18.tgz",
+      "integrity": "sha512-d+9B9Y4JsbbPg+QU+gs7S64uQSr8HiRZScNEB48ru3d4jPHthH4GSa1ZVsJEMeddg3N/SouRJIgNa2vvSfWrAw==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@adiwajshing/keyed-db": "^0.2.4",
-    "@crysnovax/baileys": "2.7.17",
+    "@crysnovax/baileys": "2.7.18",
     "@distube/ytdl-core": "^4.16.12",
     "@faker-js/faker": "^10.3.0",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",


### PR DESCRIPTION
Updates CODY to the published @crysnovax/baileys@2.7.18 release.

2.7.18 contains the RichGen replacement implementation aligned with the referenced MessageBuilderV4.7 pattern: botForwardedMessage.message.protocolMessage, the original message key, MESSAGE_EDIT/type 14, and the complete generated rich message as editedMessage.

Validation: clean npm ci with scripts disabled, installed version 2.7.18 confirmed, published package contains the reference wrapper, RichGen and ban/status tests pass 7/7, syntax checks pass, and git diff --check passes.

Unrelated runtime database files were excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Baileys integration to version 2.7.18 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->