### PR TITLE
feat: add local WebView Mini App test command

### DIFF
--- a/src/Commands/Owner/webviewtest.js
+++ b/src/Commands/Owner/webviewtest.js
@@ -1,0 +1,37 @@
+// CODY WebView test command: owner-only local Mini App launch using the published sendRichWebview helper.
+const LOCAL_MINI_APP_URL = process.env.CODY_MINIAPP_URL || 'https://3000-i7qaim3ry4869h3torapz-4aeb5eaa.us3.manus.computer/';
+
+module.exports = {
+    name: 'webviewtest',
+    alias: ['miniapp', 'signalapp', 'wvtest'],
+    desc: 'Open the local CODY Signal Arcade Mini App',
+    category: 'Owner',
+    owner: true,
+    reactions: { start: '📡', success: '✅', error: '❔' },
+
+    execute: async (sock, m, { reply }) => {
+        try {
+            if (typeof sock.sendRichWebview !== 'function') {
+                throw new Error('sendRichWebview is unavailable; update @crysnovax/baileys first');
+            }
+
+            await sock.sendMessage(m.chat, { react: { text: '📡', key: m.key } });
+            await sock.sendRichWebview(m.chat, {
+                title: 'CODY Signal Arcade',
+                text: 'Tap the signal and watch the relay. Local WebView test surface for CODY.',
+                buttonText: 'Open Signal Arcade',
+                url: LOCAL_MINI_APP_URL,
+                useWebview: true,
+                toast: 'Opening Signal Arcade…',
+                footer: 'Local test / no Worker connected'
+            }, { quoted: m });
+            await sock.sendMessage(m.chat, { react: { text: '✅', key: m.key } });
+        } catch (error) {
+            console.error('[WEBVIEWTEST ERROR]', error.message);
+            await sock.sendMessage(m.chat, { react: { text: '❔', key: m.key } });
+            return reply(`✘ WebView test failed: ${error.message}`);
+        }
+    }
+};
+
+module.exports.LOCAL_MINI_APP_URL = LOCAL_MINI_APP_URL;

--- a/tests/webviewtest-command.test.mjs
+++ b/tests/webviewtest-command.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const command = require('../src/Commands/Owner/webviewtest.js');
+
+test('webviewtest is owner-only and uses the temporary local Mini App URL', async () => {
+  const calls = [];
+  const sock = {
+    sendMessage: async (...args) => calls.push(['sendMessage', ...args]),
+    sendRichWebview: async (...args) => calls.push(['sendRichWebview', ...args])
+  };
+  const message = { chat: '123@s.whatsapp.net', key: { id: 'abc' } };
+  const replies = [];
+
+  await command.execute(sock, message, { reply: async (text) => replies.push(text) });
+
+  assert.equal(command.owner, true);
+  assert.equal(replies.length, 0);
+  const webview = calls.find(([name]) => name === 'sendRichWebview');
+  assert.ok(webview);
+  assert.equal(webview[1], message.chat);
+  assert.equal(webview[2].url, command.LOCAL_MINI_APP_URL);
+  assert.equal(webview[2].useWebview, true);
+  assert.equal(webview[2].buttonText, 'Open Signal Arcade');
+  assert.equal(webview[2].toast, 'Opening Signal Arcade…');
+  assert.deepEqual(webview[3], { quoted: message });
+});
+
+test('webviewtest reports unavailable helper without throwing', async () => {
+  const reactions = [];
+  const replies = [];
+  const sock = { sendMessage: async (...args) => reactions.push(args) };
+  const message = { chat: '123@s.whatsapp.net', key: { id: 'abc' } };
+
+  await command.execute(sock, message, { reply: async (text) => replies.push(text) });
+
+  assert.match(replies[0], /sendRichWebview is unavailable/);
+  assert.equal(reactions.at(-1)[1].react.text, '❔');
+});


### PR DESCRIPTION
Adds an owner-only /webviewtest command for launching the temporary CODY Signal Arcade Mini App through sendRichWebview().

Includes aliases /miniapp, /signalapp, and /wvtest; immediate toast metadata; quoted context; no-Worker footer; and focused tests for URL, button, useWebview, toast, and unavailable-helper behavior.

Validation: focused tests 9/9, syntax checks, local Mini App HTTP 200, and git diff --check.