### PR TITLE
feat: add Pocket Relay pool game launcher

### DIFF
--- a/src/Commands/Owner/poolgame.js
+++ b/src/Commands/Owner/poolgame.js
@@ -1,0 +1,36 @@
+// CODY pool-game command: owner-only launch for the compact local Pocket Relay Mini App.
+const LOCAL_POOL_GAME_URL = process.env.CODY_POOL_GAME_URL || 'https://3000-i7qaim3ry4869h3torapz-4aeb5eaa.us3.manus.computer/pool';
+
+module.exports = {
+    name: 'poolgame',
+    alias: ['pool', 'pocketrelay', '8ball'],
+    desc: 'Open the local Pocket Relay pool game',
+    category: 'Owner',
+    owner: true,
+    reactions: { start: '🎱', success: '✅', error: '❔' },
+
+    execute: async (sock, m, { reply }) => {
+        try {
+            if (typeof sock.sendRichWebview !== 'function') {
+                throw new Error('sendRichWebview is unavailable; update @crysnovax/baileys first');
+            }
+            await sock.sendMessage(m.chat, { react: { text: '🎱', key: m.key } });
+            await sock.sendRichWebview(m.chat, {
+                title: 'Pocket Relay',
+                text: 'A small pool game in your WebView. Choose a ball, shoot, and send your score.',
+                buttonText: 'Open Pool Game',
+                url: LOCAL_POOL_GAME_URL,
+                useWebview: true,
+                toast: 'Opening Pocket Relay…',
+                footer: 'Local game test / no Worker connected'
+            }, { quoted: m });
+            await sock.sendMessage(m.chat, { react: { text: '✅', key: m.key } });
+        } catch (error) {
+            console.error('[POOLGAME ERROR]', error.message);
+            await sock.sendMessage(m.chat, { react: { text: '❔', key: m.key } });
+            return reply(`✘ Pool game launch failed: ${error.message}`);
+        }
+    }
+};
+
+module.exports.LOCAL_POOL_GAME_URL = LOCAL_POOL_GAME_URL;

--- a/tests/poolgame-command.test.mjs
+++ b/tests/poolgame-command.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const command = require('../src/Commands/Owner/poolgame.js');
+
+test('poolgame is owner-only and launches the compact Pocket Relay route', async () => {
+  const calls = [];
+  const sock = {
+    sendMessage: async (...args) => calls.push(['sendMessage', ...args]),
+    sendRichWebview: async (...args) => calls.push(['sendRichWebview', ...args])
+  };
+  const message = { chat: '123@s.whatsapp.net', key: { id: 'pool-test' } };
+  const replies = [];
+
+  await command.execute(sock, message, { reply: async (text) => replies.push(text) });
+
+  assert.equal(command.owner, true);
+  assert.equal(replies.length, 0);
+  const webview = calls.find(([name]) => name === 'sendRichWebview');
+  assert.ok(webview);
+  assert.equal(webview[1], message.chat);
+  assert.match(webview[2].url, /\/pool$/);
+  assert.equal(webview[2].useWebview, true);
+  assert.equal(webview[2].buttonText, 'Open Pool Game');
+  assert.equal(webview[2].toast, 'Opening Pocket Relay…');
+  assert.deepEqual(webview[3], { quoted: message });
+});
+
+test('poolgame reports a missing WebView helper without throwing', async () => {
+  const replies = [];
+  const sock = { sendMessage: async () => {} };
+  const message = { chat: '123@s.whatsapp.net', key: { id: 'pool-test' } };
+
+  await command.execute(sock, message, { reply: async (text) => replies.push(text) });
+
+  assert.match(replies[0], /sendRichWebview is unavailable/);
+});


### PR DESCRIPTION
Adds an owner-only /poolgame command with aliases /pool, /pocketrelay, and /8ball. The command launches the separate compact Pocket Relay Mini App through sendRichWebview with useWebview, immediate toast, quoted context, and a local no-Worker footer.

Validation: poolgame, webviewtest, RichGen, and ban/status tests 11/11; syntax checks; local /pool HTTP 200; and git diff --check.