### PR TITLE
feat: add native in-message pool card

### DIFF
--- a/src/Commands/Owner/poolcard.js
+++ b/src/Commands/Owner/poolcard.js
@@ -1,0 +1,73 @@
+// Native pool-card game: an in-chat rich card, not a WebView or URL launcher.
+const sessions = new Map();
+const CARD_IMAGE = process.env.CODY_POOL_CARD_IMAGE_URL || 'https://3000-i7qaim3ry4869h3torapz-4aeb5eaa.us3.manus.computer/manus-storage/signal-arcade-hero_52d44784.png';
+
+const stateFor = (session) => {
+    const balls = ['●', '◆', '●', '◆', '●'];
+    const board = session.sunk > 0 ? balls.map((ball, index) => index < session.sunk ? '·' : ball).join('  ') : balls.join('  ');
+    const status = session.lastResult || 'Choose BET + or SHOOT';
+    return {
+        title: 'POCKET RELAY · POOL TABLE',
+        image: { url: CARD_IMAGE },
+        caption: [
+            '🎱  POCKET RELAY',
+            `CREDITS  ${session.credits}     BET  ${session.bet}     BEST WIN  ${session.bestWin}`,
+            '',
+            `      ◉  ${board}  ◉`,
+            '',
+            `              ${status}`
+        ].join('\n'),
+        buttons: [
+            { id: 'poolcard:bet', text: `BET +${session.bet}` },
+            { id: 'poolcard:shoot', text: 'SHOOT' },
+            { id: 'poolcard:reset', text: 'RESET' }
+        ]
+    };
+};
+
+const keyFor = (m) => `${m.chat}:${m.quoted?.key?.id || m.message?.extendedTextMessage?.contextInfo?.stanzaId || m.key?.id || 'latest'}`;
+
+const poolcard = {
+    name: 'poolcard',
+    alias: ['poolrich', 'pooltable'],
+    desc: 'Send an interactive native pool rich card',
+    category: 'Owner',
+    owner: true,
+    reactions: { start: '🎱', success: '✅', error: '❔' },
+
+    execute: async (sock, m, { args = [], reply }) => {
+        if (typeof sock.sendRichButtonGrid !== 'function') {
+            return reply('sendRichButtonGrid is unavailable; update @crysnovax/baileys first.');
+        }
+        const action = String(args[0] || '').toLowerCase();
+        if (!action) {
+            const session = { credits: 530, bet: 10, bestWin: 0, sunk: 0, lastResult: null };
+            const sent = await sock.sendRichButtonGrid(m.chat, { text: '🎱 POCKET RELAY', footer: 'Native in-message game · tap a control', cards: [stateFor(session)] }, { quoted: m });
+            const messageId = sent?.key?.id || sent?.messageId;
+            if (!messageId) return reply('Pool card sent without a message key; updates cannot be attached.');
+            sessions.set(`${m.chat}:${messageId}`, { ...session, messageId });
+            return;
+        }
+
+        const targetId = m.quoted?.key?.id || m.message?.extendedTextMessage?.contextInfo?.stanzaId;
+        const sessionKey = targetId ? `${m.chat}:${targetId}` : [...sessions.keys()].reverse().find((key) => key.startsWith(`${m.chat}:`));
+        const session = sessionKey ? sessions.get(sessionKey) : null;
+        if (!session) return reply('Pool card session expired. Send /poolcard again.');
+        if (action === 'reset') Object.assign(session, { credits: 530, bet: 10, bestWin: 0, sunk: 0, lastResult: 'Table reset' });
+        else if (action === 'bet') {
+            if (session.credits < session.bet) session.lastResult = 'Not enough credits';
+            else { session.credits -= session.bet; session.lastResult = `Bet placed · ${session.bet}`; }
+        } else if (action === 'shoot') {
+            const win = session.bet * (session.sunk % 2 === 0 ? 10 : 4);
+            session.credits += win; session.bestWin = Math.max(session.bestWin, win); session.sunk = (session.sunk + 1) % 5; session.lastResult = `WIN +${win}`;
+        } else return reply('Use the buttons on the pool card.');
+
+        const updated = stateFor(session);
+        await sock.sendMessage(m.chat, { text: updated.caption, footer: 'Native in-message game · tap a control', cards: [updated] }, { edit: { remoteJid: m.chat, id: session.messageId } });
+        await sock.sendMessage(m.chat, { react: { text: '✅', key: m.key } }).catch(() => {});
+    }
+};
+
+module.exports = poolcard;
+module.exports.sessions = sessions;
+module.exports.stateFor = stateFor;

--- a/src/Plugin/deployButtonRouter.js
+++ b/src/Plugin/deployButtonRouter.js
@@ -1,3 +1,9 @@
+const POOL_BUTTON_COMMANDS = new Map([
+    ['poolcard:bet', '.poolcard bet'],
+    ['poolcard:shoot', '.poolcard shoot'],
+    ['poolcard:reset', '.poolcard reset'],
+]);
+
 const DEPLOY_BUTTON_COMMANDS = new Map([
     ['step 1 · discord', '.deploy step1'],
     ['step 1 - discord', '.deploy step1'],
@@ -19,6 +25,8 @@ const DEPLOY_BUTTON_COMMANDS = new Map([
 const normalizeDeployButton = value => {
     const text = String(value || '').trim();
     if (!text) return null;
+    const poolAction = POOL_BUTTON_COMMANDS.get(text.toLowerCase());
+    if (poolAction) return poolAction;
     const menuScoped = text.match(/^\.deploy\s+(step[1-4]|help|tutorials|menu)(?:\s+--menu=[a-z0-9_-]+)?$/i);
     if (menuScoped) return `.deploy ${menuScoped[1].toLowerCase()}`;
     const deployScoped = text.match(/^deploy:(step[1-4]|help|tutorials|menu)(?:\s+--menu=[a-z0-9_-]+)?$/i);
@@ -102,5 +110,6 @@ module.exports = {
     normalizeDeployButton,
     normalizeDeployButtonMessage,
     extractDeployButtonValues,
-    DEPLOY_BUTTON_COMMANDS
+    DEPLOY_BUTTON_COMMANDS,
+    POOL_BUTTON_COMMANDS
 };

--- a/tests/poolcard-command.test.mjs
+++ b/tests/poolcard-command.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const command = require('../src/Commands/Owner/poolcard.js');
+const { normalizeDeployButton } = require('../src/Plugin/deployButtonRouter.js');
+
+const baseMessage = { chat: '123@s.whatsapp.net', key: { id: 'command-1' } };
+
+test('poolcard sends a native in-message card with no URL CTA', async () => {
+  const calls = [];
+  const sock = { sendRichButtonGrid: async (...args) => { calls.push(args); return { key: { id: 'pool-card-1' } }; } };
+  await command.execute(sock, baseMessage, { args: [], reply: async () => {} });
+  assert.equal(calls.length, 1);
+  const payload = calls[0][1];
+  assert.equal(payload.cards.length, 1);
+  assert.equal(payload.cards[0].buttons[0].id, 'poolcard:bet');
+  assert.equal(payload.cards[0].buttons[1].id, 'poolcard:shoot');
+  assert.equal('url' in payload.cards[0], false);
+  assert.match(payload.cards[0].caption, /CREDITS/);
+});
+
+test('pool buttons normalize to poolcard actions', () => {
+  assert.equal(normalizeDeployButton('poolcard:bet'), '.poolcard bet');
+  assert.equal(normalizeDeployButton('poolcard:shoot'), '.poolcard shoot');
+  assert.equal(normalizeDeployButton('poolcard:reset'), '.poolcard reset');
+});
+
+test('poolcard updates the original card through sendMessage edit', async () => {
+  const calls = [];
+  const sock = {
+    sendRichButtonGrid: async () => ({ key: { id: 'pool-card-2' } }),
+    sendMessage: async (...args) => { calls.push(args); return {}; }
+  };
+  await command.execute(sock, baseMessage, { args: [], reply: async () => {} });
+  const buttonMessage = { chat: baseMessage.chat, key: { id: 'button-1' }, quoted: { key: { id: 'pool-card-2' } } };
+  await command.execute(sock, buttonMessage, { args: ['shoot'], reply: async () => {} });
+  const edit = calls.find(([, content, options]) => options?.edit);
+  assert.ok(edit);
+  assert.deepEqual(edit[2].edit, { remoteJid: baseMessage.chat, id: 'pool-card-2' });
+  assert.match(edit[1].cards[0].caption, /WIN/);
+});


### PR DESCRIPTION
Adds an owner-only /poolcard command with /poolrich and /pooltable aliases. It sends a compact native rich card directly in WhatsApp with credits, bet, board, status, and BET/SHOOT/RESET controls—no URL or WebView CTA.

Pool callback IDs normalize through the existing interactive response path and update the original message using the Baileys edit option.

Validation: native pool card, callback normalization, RichGen, WebView, and ban/status tests 14/14; syntax checks; and git diff --check.