### PR TITLE
fix: route native pool card commands unambiguously

### DIFF
--- a/src/Commands/Owner/poolcard.js
+++ b/src/Commands/Owner/poolcard.js
@@ -29,7 +29,7 @@ const keyFor = (m) => `${m.chat}:${m.quoted?.key?.id || m.message?.extendedTextM
 
 const poolcard = {
     name: 'poolcard',
-    alias: ['poolrich', 'pooltable'],
+    alias: ['nativepool', 'poolrich', 'pooltable'],
     desc: 'Send an interactive native pool rich card',
     category: 'Owner',
     owner: true,
@@ -52,7 +52,7 @@ const poolcard = {
         const targetId = m.quoted?.key?.id || m.message?.extendedTextMessage?.contextInfo?.stanzaId;
         const sessionKey = targetId ? `${m.chat}:${targetId}` : [...sessions.keys()].reverse().find((key) => key.startsWith(`${m.chat}:`));
         const session = sessionKey ? sessions.get(sessionKey) : null;
-        if (!session) return reply('Pool card session expired. Send /poolcard again.');
+        if (!session) return reply('Pool card session expired. Send .nativepool again.');
         if (action === 'reset') Object.assign(session, { credits: 530, bet: 10, bestWin: 0, sunk: 0, lastResult: 'Table reset' });
         else if (action === 'bet') {
             if (session.credits < session.bet) session.lastResult = 'Not enough credits';

--- a/src/Commands/Owner/poolgame.js
+++ b/src/Commands/Owner/poolgame.js
@@ -3,7 +3,7 @@ const LOCAL_POOL_GAME_URL = process.env.CODY_POOL_GAME_URL || 'https://3000-i7qa
 
 module.exports = {
     name: 'poolgame',
-    alias: ['pool', 'pocketrelay', '8ball'],
+    alias: ['pool', 'pocketrelay'],
     desc: 'Open the local Pocket Relay pool game',
     category: 'Owner',
     owner: true,

--- a/tests/pool-routing.test.mjs
+++ b/tests/pool-routing.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { addCommand, clearRegistry, getCommand } = require('../src/Plugin/crysCmd.js');
+const poolgame = require('../src/Commands/Owner/poolgame.js');
+const poolcard = require('../src/Commands/Owner/poolcard.js');
+const eightBall = require('../src/Commands/Games/8ball.js');
+
+test('pool command names do not collide with old WebView or 8ball commands', () => {
+  clearRegistry();
+  addCommand(eightBall);
+  addCommand(poolgame);
+  addCommand(poolcard);
+
+  assert.equal(getCommand('poolgame'), poolgame);
+  assert.equal(getCommand('pool'), poolgame);
+  assert.equal(getCommand('nativepool'), poolcard);
+  assert.equal(getCommand('pooltable'), poolcard);
+  assert.equal(getCommand('8ball'), eightBall);
+  clearRegistry();
+});


### PR DESCRIPTION
Follow-up to merged PR #70.

The deployed test showed /poolgame still opens the old WebView launcher and /pooltable falls through to the Gen4 guide. This follow-up removes the 8ball alias from the old poolgame WebView command, adds the unambiguous nativepool alias to poolcard, preserves pooltable for the native card, and adds registry collision coverage.

Validation: command-routing, native pool-card, RichGen, WebView, and ban/status tests 15/15; syntax checks; git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `.nativepool` as an alias for the pool card command.
  * Updated expired-session guidance to use `.nativepool`.

* **Bug Fixes**
  * Removed the conflicting `8ball` alias from the pool game command, preserving the `pool` and `pocketrelay` commands.
  * Improved command routing reliability when pool and 8-ball commands are used together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->