### PR TITLE
fix: dispatch native pool commands before fallback

### DIFF
--- a/src/Commands/Owner/poolcard.js
+++ b/src/Commands/Owner/poolcard.js
@@ -33,6 +33,7 @@ const poolcard = {
     desc: 'Send an interactive native pool rich card',
     category: 'Owner',
     owner: true,
+    ownerOnly: true,
     reactions: { start: '🎱', success: '✅', error: '❔' },
 
     execute: async (sock, m, { args = [], reply }) => {

--- a/src/Plugin/crysMsg.js
+++ b/src/Plugin/crysMsg.js
@@ -251,7 +251,35 @@ const handleMessage = async (sock, m, store) => {
             }
         }
 
-        // ── PREFIX HANDLING — supports no-prefix mode ──
+        // Native pool cards may be tapped as `/pooltable` on clients whose
+        // configured prefix is `.`, and button callbacks may arrive without
+        // the configured prefix. Dispatch these exact actions before generic
+        // prefix/fallback handling so they can never fall through to deploy.
+        const nativePoolMatch = body.trim().match(/^[/.](pooltable|poolcard|nativepool|poolrich)(?:\s+(.+))?$/i);
+        if (nativePoolMatch) {
+            const nativePool = getCommand('pooltable');
+            if (nativePool) {
+                if (!isOwner && !isDual) return;
+                const poolArgs = nativePoolMatch[2] ? nativePoolMatch[2].trim().split(/ +/) : [];
+                const poolReply = (txt, options = {}) => sock.sendMessage(m.chat, { text: txt, ...options }, { quoted: m });
+                return nativePool.execute(sock, m, {
+                    args: poolArgs,
+                    text: poolArgs.join(' '),
+                    prefix: body.trim()[0],
+                    command: 'pooltable',
+                    isOwner,
+                    isSudo,
+                    isDual,
+                    isGroup: m.isGroup,
+                    reply: poolReply,
+                    config: cfg,
+                    store,
+                    getVar
+                });
+            }
+        }
+
+        // ── PREFIX HANDLING — supports null/empty for no-prefix mode ──
         let cmdName, args, text;
 
         if (prefix === '') {

--- a/tests/pool-dispatch-guard.test.mjs
+++ b/tests/pool-dispatch-guard.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const source = readFileSync(new URL('../src/Plugin/crysMsg.js', import.meta.url), 'utf8');
+
+test('crysMsg has an explicit native pool dispatch guard before generic prefix parsing', () => {
+  const guard = source.indexOf('const nativePoolMatch');
+  const prefixParser = source.indexOf('// ── PREFIX HANDLING');
+  assert.ok(guard >= 0, 'native pool guard is missing');
+  assert.ok(prefixParser >= 0, 'generic prefix parser is missing');
+  assert.ok(guard < prefixParser, 'pool guard must run before generic prefix parsing');
+  assert.match(source, /\^\[\/.\]\(pooltable\|poolcard\|nativepool\|poolrich\)/);
+  assert.match(source, /getCommand\('pooltable'\)/);
+});
+
+test('pooltable command declares owner-only access', () => {
+  const poolcard = readFileSync(new URL('../src/Commands/Owner/poolcard.js', import.meta.url), 'utf8');
+  assert.match(poolcard, /name: 'pooltable'/);
+  assert.match(poolcard, /ownerOnly: true/);
+});


### PR DESCRIPTION
Adds a high-priority dispatch guard for /pooltable, /poolcard, /nativepool, and /poolrich before generic prefix parsing. This prevents those exact commands from reaching deploy or unknown-command fallback logic.

The canonical pooltable command is owner-only, and the guard passes pool button actions to the existing command implementation.

Validation: pool dispatch, routing, native card, RichGen, WebView, and ban/status tests 15/15; syntax checks; git diff --check.