### PR TITLE
fix: allow self-chat native pool dispatch

### DIFF
--- a/src/Plugin/crysMsg.js
+++ b/src/Plugin/crysMsg.js
@@ -259,15 +259,19 @@ const handleMessage = async (sock, m, store) => {
         if (nativePoolMatch) {
             const nativePool = getCommand('pooltable');
             if (nativePool) {
-                if (!isOwner && !isDual) return;
-                const poolArgs = nativePoolMatch[2] ? nativePoolMatch[2].trim().split(/ +/) : [];
                 const poolReply = (txt, options = {}) => sock.sendMessage(m.chat, { text: txt, ...options }, { quoted: m });
+                // In a WhatsApp self-chat, the sender may be represented by a
+                // LID that does not match OWNER_NUMBER. fromMe is the reliable
+                // owner signal for that local test flow; never fail silently.
+                const nativePoolOwner = isOwner || isDual || !!m.key?.fromMe || !!m.fromMe;
+                if (!nativePoolOwner) return poolReply(cfg.message?.owner || 'Owner only!');
+                const poolArgs = nativePoolMatch[2] ? nativePoolMatch[2].trim().split(/ +/) : [];
                 return nativePool.execute(sock, m, {
                     args: poolArgs,
                     text: poolArgs.join(' '),
                     prefix: body.trim()[0],
                     command: 'pooltable',
-                    isOwner,
+                    isOwner: nativePoolOwner,
                     isSudo,
                     isDual,
                     isGroup: m.isGroup,

--- a/tests/pool-dispatch-guard.test.mjs
+++ b/tests/pool-dispatch-guard.test.mjs
@@ -12,6 +12,8 @@ test('crysMsg has an explicit native pool dispatch guard before generic prefix p
   assert.ok(guard < prefixParser, 'pool guard must run before generic prefix parsing');
   assert.match(source, /\^\[\/.\]\(pooltable\|poolcard\|nativepool\|poolrich\)/);
   assert.match(source, /getCommand\('pooltable'\)/);
+  assert.match(source, /const nativePoolOwner = isOwner \|\| isDual \|\| !!m\.key\?\.fromMe \|\| !!m\.fromMe/);
+  assert.match(source, /if \(!nativePoolOwner\) return poolReply\(/);
 });
 
 test('pooltable command declares owner-only access', () => {


### PR DESCRIPTION
Fixes the silent /pooltable result in WhatsApp self-chat. The live registry contains pooltable, but the incoming message may use a LID that does not match OWNER_NUMBER. The dispatch guard now recognizes fromMe as the owner signal and returns an explicit owner-only response for other senders instead of silently returning.

Validation: pool dispatch, routing, native card, RichGen, and ban/status tests 13/13; syntax checks; git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Self-sent pool commands are now correctly recognized as owner-authorized.
  * Unauthorized pool requests now receive an explicit response instead of being silently ignored.
  * Authorization status is passed consistently when processing pool commands.

* **Tests**
  * Added coverage for owner detection and non-owner response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->