### PR TITLE
refactor: use standard pool command dispatch

### DIFF
--- a/src/Plugin/crysMsg.js
+++ b/src/Plugin/crysMsg.js
@@ -259,15 +259,19 @@ const handleMessage = async (sock, m, store) => {
         if (nativePoolMatch) {
             const nativePool = getCommand('pooltable');
             if (nativePool) {
-                if (!isOwner && !isDual) return;
-                const poolArgs = nativePoolMatch[2] ? nativePoolMatch[2].trim().split(/ +/) : [];
                 const poolReply = (txt, options = {}) => sock.sendMessage(m.chat, { text: txt, ...options }, { quoted: m });
+                // In a WhatsApp self-chat, the sender may be represented by a
+                // LID that does not match OWNER_NUMBER. fromMe is the reliable
+                // owner signal for that local test flow; never fail silently.
+                const nativePoolOwner = isOwner || isDual || !!m.key?.fromMe || !!m.fromMe;
+                if (!nativePoolOwner) return poolReply(cfg.message?.owner || 'Owner only!');
+                const poolArgs = nativePoolMatch[2] ? nativePoolMatch[2].trim().split(/ +/) : [];
                 return nativePool.execute(sock, m, {
                     args: poolArgs,
                     text: poolArgs.join(' '),
                     prefix: body.trim()[0],
                     command: 'pooltable',
-                    isOwner,
+                    isOwner: nativePoolOwner,
                     isSudo,
                     isDual,
                     isGroup: m.isGroup,

--- a/src/Plugin/crysMsg.js
+++ b/src/Plugin/crysMsg.js
@@ -251,38 +251,6 @@ const handleMessage = async (sock, m, store) => {
             }
         }
 
-        // Native pool cards may be tapped as `/pooltable` on clients whose
-        // configured prefix is `.`, and button callbacks may arrive without
-        // the configured prefix. Dispatch these exact actions before generic
-        // prefix/fallback handling so they can never fall through to deploy.
-        const nativePoolMatch = body.trim().match(/^[/.](pooltable|poolcard|nativepool|poolrich)(?:\s+(.+))?$/i);
-        if (nativePoolMatch) {
-            const nativePool = getCommand('pooltable');
-            if (nativePool) {
-                const poolReply = (txt, options = {}) => sock.sendMessage(m.chat, { text: txt, ...options }, { quoted: m });
-                // In a WhatsApp self-chat, the sender may be represented by a
-                // LID that does not match OWNER_NUMBER. fromMe is the reliable
-                // owner signal for that local test flow; never fail silently.
-                const nativePoolOwner = isOwner || isDual || !!m.key?.fromMe || !!m.fromMe;
-                if (!nativePoolOwner) return poolReply(cfg.message?.owner || 'Owner only!');
-                const poolArgs = nativePoolMatch[2] ? nativePoolMatch[2].trim().split(/ +/) : [];
-                return nativePool.execute(sock, m, {
-                    args: poolArgs,
-                    text: poolArgs.join(' '),
-                    prefix: body.trim()[0],
-                    command: 'pooltable',
-                    isOwner: nativePoolOwner,
-                    isSudo,
-                    isDual,
-                    isGroup: m.isGroup,
-                    reply: poolReply,
-                    config: cfg,
-                    store,
-                    getVar
-                });
-            }
-        }
-
         // ── PREFIX HANDLING — supports null/empty for no-prefix mode ──
         let cmdName, args, text;
 

--- a/tests/pool-dispatch-guard.test.mjs
+++ b/tests/pool-dispatch-guard.test.mjs
@@ -12,6 +12,8 @@ test('crysMsg has an explicit native pool dispatch guard before generic prefix p
   assert.ok(guard < prefixParser, 'pool guard must run before generic prefix parsing');
   assert.match(source, /\^\[\/.\]\(pooltable\|poolcard\|nativepool\|poolrich\)/);
   assert.match(source, /getCommand\('pooltable'\)/);
+  assert.match(source, /const nativePoolOwner = isOwner \|\| isDual \|\| !!m\.key\?\.fromMe \|\| !!m\.fromMe/);
+  assert.match(source, /if \(!nativePoolOwner\) return poolReply\(/);
 });
 
 test('pooltable command declares owner-only access', () => {

--- a/tests/pool-dispatch-guard.test.mjs
+++ b/tests/pool-dispatch-guard.test.mjs
@@ -4,16 +4,16 @@ import test from 'node:test';
 
 const source = readFileSync(new URL('../src/Plugin/crysMsg.js', import.meta.url), 'utf8');
 
-test('crysMsg has an explicit native pool dispatch guard before generic prefix parsing', () => {
-  const guard = source.indexOf('const nativePoolMatch');
+test('pooltable uses the ordinary command registry path', () => {
   const prefixParser = source.indexOf('// ── PREFIX HANDLING');
-  assert.ok(guard >= 0, 'native pool guard is missing');
+  const registryLookup = source.indexOf('const cmd = getCommand(cmdName);');
+
   assert.ok(prefixParser >= 0, 'generic prefix parser is missing');
-  assert.ok(guard < prefixParser, 'pool guard must run before generic prefix parsing');
-  assert.match(source, /\^\[\/.\]\(pooltable\|poolcard\|nativepool\|poolrich\)/);
-  assert.match(source, /getCommand\('pooltable'\)/);
-  assert.match(source, /const nativePoolOwner = isOwner \|\| isDual \|\| !!m\.key\?\.fromMe \|\| !!m\.fromMe/);
-  assert.match(source, /if \(!nativePoolOwner\) return poolReply\(/);
+  assert.ok(registryLookup > prefixParser, 'command registry lookup must follow prefix parsing');
+  assert.equal(source.includes('const nativePoolMatch'), false, 'pooltable must not have a special central parser guard');
+  assert.equal(source.includes('nativePoolOwner'), false, 'pooltable must use the standard owner check');
+  assert.match(source, /if \(!body\.startsWith\(prefix\)\) return;/);
+  assert.match(source, /if \(!cmd\) return;/);
 });
 
 test('pooltable command declares owner-only access', () => {


### PR DESCRIPTION
Removes the unnecessary central pool-specific dispatch guard and returns pooltable to the same normal prefix, command registry, owner check, and execute path used by working CODY commands.

The native card callback router remains unchanged. The command must use CODY’s configured prefix; when the bot prefix is a dot, send `.pooltable`, not `/pooltable`.

Validation: pool, RichGen, WebView, and ban/status tests 13/13; syntax checks; git diff --check.