### PR TITLE
feat: add first-pass native Pocket Relay card

### DIFF
--- a/src/Commands/Owner/poolcard.js
+++ b/src/Commands/Owner/poolcard.js
@@ -1,24 +1,51 @@
-// Native pool-card game: an in-chat rich card, not a WebView or URL launcher.
+/*
+ * Pocket Relay native rich-game surface.
+ * Design target: a tall, composed WhatsApp message card with a visual game
+ * panel, compact stats, native controls, and in-place state replacement.
+ * This is intentionally a first pass; the gameplay is harmless and local to
+ * the bot process, with no WebView URL and no crash-testing behavior.
+ */
+
 const sessions = new Map();
-const CARD_IMAGE = process.env.CODY_POOL_CARD_IMAGE_URL || 'https://3000-i7qaim3ry4869h3torapz-4aeb5eaa.us3.manus.computer/manus-storage/signal-arcade-hero_52d44784.png';
+const CARD_IMAGE = process.env.CODY_POOL_CARD_IMAGE_URL || 'https://files.manuscdn.com/user_upload_by_module/session_file/310519663721894305/rFZreqMAZlaslttv.png';
+
+const REELS = [
+    ['🍒', '7️⃣', '💎', '🔔', '🍋'],
+    ['🍋', '🔔', '🔔', '7️⃣', '🍒'],
+    ['💎', '🍒', '🍋', '🍒', '7️⃣'],
+    ['🔔', '🍒', '7️⃣', '💎', '🍋'],
+    ['🍒', '🍋', '💎', '🔔', '🍒'],
+];
+
+const reelLines = (step) => {
+    const row = REELS[step % REELS.length];
+    const next = REELS[(step + 1) % REELS.length];
+    const third = REELS[(step + 2) % REELS.length];
+    return [row, next, third].map((line) => `│ ${line.join(' │ ')} │`).join('\n');
+};
 
 const stateFor = (session) => {
-    const balls = ['●', '◆', '●', '◆', '●'];
-    const board = session.sunk > 0 ? balls.map((ball, index) => index < session.sunk ? '·' : ball).join('  ') : balls.join('  ');
-    const status = session.lastResult || 'Choose BET + or SHOOT';
+    const status = session.lastResult || 'Good luck · choose your shot';
     return {
         title: 'POCKET RELAY · POOL TABLE',
         image: { url: CARD_IMAGE },
         caption: [
             '🎱  POCKET RELAY',
+            'JACKPOT  ·  10,000 CREDITS',
+            '',
             `CREDITS  ${session.credits}     BET  ${session.bet}     BEST WIN  ${session.bestWin}`,
             '',
-            `      ◉  ${board}  ◉`,
+            '╭────────────────────────────╮',
+            reelLines(session.spin),
+            '╰────────────────────────────╯',
             '',
-            `              ${status}`
+            `                 ${status}`,
+            '',
+            '      [ BET + ]          [ SHOOT ]',
+            '           POCKET RELAY · BEST OF 3'
         ].join('\n'),
         buttons: [
-            { id: 'poolcard:bet', text: `BET +${session.bet}` },
+            { id: 'poolcard:bet', text: 'BET +' },
             { id: 'poolcard:shoot', text: 'SHOOT' },
             { id: 'poolcard:reset', text: 'RESET' }
         ]
@@ -30,7 +57,7 @@ const keyFor = (m) => `${m.chat}:${m.quoted?.key?.id || m.message?.extendedTextM
 const poolcard = {
     name: 'pooltable',
     alias: ['poolcard', 'nativepool', 'poolrich'],
-    desc: 'Send an interactive native pool rich card',
+    desc: 'Send an interactive native Pocket Relay game card',
     category: 'Owner',
     owner: true,
     ownerOnly: true,
@@ -40,31 +67,60 @@ const poolcard = {
         if (typeof sock.sendRichButtonGrid !== 'function') {
             return reply('sendRichButtonGrid is unavailable; update @crysnovax/baileys first.');
         }
+
         const action = String(args[0] || '').toLowerCase();
         if (!action) {
-            const session = { credits: 530, bet: 10, bestWin: 0, sunk: 0, lastResult: null };
-            const sent = await sock.sendRichButtonGrid(m.chat, { text: '🎱 POCKET RELAY', footer: 'Native in-message game · tap a control', cards: [stateFor(session)] }, { quoted: m });
+            const session = { credits: 530, bet: 10, bestWin: 0, spin: 0, lastResult: null };
+            const sent = await sock.sendRichButtonGrid(
+                m.chat,
+                { text: '🎱 POCKET RELAY', footer: 'Native game surface · tap a control', cards: [stateFor(session)] },
+                { quoted: m }
+            );
             const messageId = sent?.key?.id || sent?.messageId;
-            if (!messageId) return reply('Pool card sent without a message key; updates cannot be attached.');
+            if (!messageId) return reply('Pocket Relay was sent without a message key; updates cannot be attached.');
             sessions.set(`${m.chat}:${messageId}`, { ...session, messageId });
             return;
         }
 
         const targetId = m.quoted?.key?.id || m.message?.extendedTextMessage?.contextInfo?.stanzaId;
-        const sessionKey = targetId ? `${m.chat}:${targetId}` : [...sessions.keys()].reverse().find((key) => key.startsWith(`${m.chat}:`));
+        const sessionKey = targetId
+            ? `${m.chat}:${targetId}`
+            : [...sessions.keys()].reverse().find((key) => key.startsWith(`${m.chat}:`));
         const session = sessionKey ? sessions.get(sessionKey) : null;
-        if (!session) return reply('Pool card session expired. Send /pooltable again.');
-        if (action === 'reset') Object.assign(session, { credits: 530, bet: 10, bestWin: 0, sunk: 0, lastResult: 'Table reset' });
-        else if (action === 'bet') {
+        if (!session) return reply('Pocket Relay session expired. Send .pooltable again.');
+
+        if (action === 'reset') {
+            Object.assign(session, { credits: 530, bet: 10, bestWin: 0, spin: 0, lastResult: 'Table reset' });
+        } else if (action === 'bet') {
             if (session.credits < session.bet) session.lastResult = 'Not enough credits';
-            else { session.credits -= session.bet; session.lastResult = `Bet placed · ${session.bet}`; }
+            else {
+                session.credits -= session.bet;
+                session.lastResult = `Bet placed · ${session.bet}`;
+            }
         } else if (action === 'shoot') {
-            const win = session.bet * (session.sunk % 2 === 0 ? 10 : 4);
-            session.credits += win; session.bestWin = Math.max(session.bestWin, win); session.sunk = (session.sunk + 1) % 5; session.lastResult = `WIN +${win}`;
-        } else return reply('Use the buttons on the pool card.');
+            const win = session.bet * (session.spin % 2 === 0 ? 6 : 3);
+            session.credits += win;
+            session.bestWin = Math.max(session.bestWin, win);
+            session.spin = (session.spin + 1) % REELS.length;
+            session.lastResult = `WIN +${win}`;
+        } else {
+            return reply('Use the native Pocket Relay controls.');
+        }
 
         const updated = stateFor(session);
-        await sock.sendMessage(m.chat, { text: updated.caption, footer: 'Native in-message game · tap a control', cards: [updated] }, { edit: { remoteJid: m.chat, id: session.messageId } });
+        if (typeof sock.updateRichGeneration === 'function') {
+            await sock.updateRichGeneration(m.chat, session.messageId, {
+                text: updated.caption,
+                footer: 'Native game surface · tap a control',
+                cards: [updated]
+            }, { forwarded: true });
+        } else {
+            await sock.sendMessage(m.chat, {
+                text: updated.caption,
+                footer: 'Native game surface · tap a control',
+                cards: [updated]
+            }, { edit: { remoteJid: m.chat, id: session.messageId } });
+        }
         await sock.sendMessage(m.chat, { react: { text: '✅', key: m.key } }).catch(() => {});
     }
 };
@@ -72,3 +128,4 @@ const poolcard = {
 module.exports = poolcard;
 module.exports.sessions = sessions;
 module.exports.stateFor = stateFor;
+module.exports.keyFor = keyFor;

--- a/tests/poolcard-command.test.js
+++ b/tests/poolcard-command.test.js
@@ -1,0 +1,65 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const poolcard = require('../src/Commands/Owner/poolcard.js');
+
+test('pooltable sends a composed visual card with native controls', async () => {
+    const calls = [];
+    const sock = {
+        sendRichButtonGrid: async (jid, payload) => {
+            calls.push({ type: 'send', jid, payload });
+            return { key: { id: 'pool-1' } };
+        }
+    };
+
+    await poolcard.execute(sock, { chat: '123@g.us' }, { args: [], reply: async () => {} });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].payload.cards.length, 1);
+    assert.ok(calls[0].payload.cards[0].image.url);
+    assert.match(calls[0].payload.cards[0].caption, /POCKET RELAY/);
+    assert.match(calls[0].payload.cards[0].caption, /CREDITS/);
+    assert.deepEqual(calls[0].payload.cards[0].buttons.map(button => button.id), [
+        'poolcard:bet', 'poolcard:shoot', 'poolcard:reset'
+    ]);
+});
+
+test('pooltable updates the same card through the native rich edit helper', async () => {
+    const updates = [];
+    const reactions = [];
+    const sock = {
+        sendRichButtonGrid: async () => ({ key: { id: 'unused' } }),
+        updateRichGeneration: async (jid, targetId, content, options) => {
+            updates.push({ jid, targetId, content, options });
+            return { targetId };
+        },
+        sendMessage: async (jid, content) => reactions.push({ jid, content })
+    };
+    const chat = '123@g.us';
+    const sessionId = `${chat}:pool-2`;
+    poolcard.sessions.set(sessionId, { credits: 530, bet: 10, bestWin: 0, spin: 0, lastResult: null, messageId: 'pool-2' });
+
+    await poolcard.execute(sock, {
+        chat,
+        quoted: { key: { id: 'pool-2' } },
+        key: { id: 'button-1' }
+    }, { args: ['shoot'], reply: async () => {} });
+
+    assert.equal(updates.length, 1);
+    assert.equal(updates[0].jid, chat);
+    assert.equal(updates[0].targetId, 'pool-2');
+    assert.equal(updates[0].options.forwarded, true);
+    assert.match(updates[0].content.cards[0].caption, /WIN \+/);
+    assert.equal(reactions.length, 1);
+    poolcard.sessions.delete(sessionId);
+});
+
+test('pooltable reports a clear helper error', async () => {
+    const replies = [];
+    await poolcard.execute({}, { chat: '123@s.whatsapp.net' }, {
+        args: [],
+        reply: async value => replies.push(value)
+    });
+    assert.equal(replies.length, 1);
+    assert.match(replies[0], /sendRichButtonGrid/i);
+});


### PR DESCRIPTION
## Summary
- add a composed Pocket Relay native rich-game card
- provide native BET +, SHOOT, and RESET controls
- update the same rich message through the native edit helper
- add regression tests for send and in-place update states

## Validation
- `node --check src/Commands/Owner/poolcard.js`
- Pocket Relay tests: 3/3 passing

This is intentionally a first pass for disposable-account rendering tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a slot-machine-style “Pocket Relay” game card with reel displays, jackpot messaging, and updated controls.
  * Added improved interactive updates for supported rich-card experiences.

* **Bug Fixes**
  * Improved error reporting when required game functionality is unavailable.
  * Enhanced session handling and cleanup after gameplay interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->