### PR TITLE
fix: make Pocket Relay first screen render

### DIFF
--- a/src/Commands/Owner/poolcard.js
+++ b/src/Commands/Owner/poolcard.js
@@ -8,6 +8,20 @@
 
 const sessions = new Map();
 const CARD_IMAGE = process.env.CODY_POOL_CARD_IMAGE_URL || 'https://files.manuscdn.com/user_upload_by_module/session_file/310519663721894305/rFZreqMAZlaslttv.png';
+let cardImagePromise;
+
+const loadCardImage = async () => {
+    if (!cardImagePromise) {
+        cardImagePromise = fetch(CARD_IMAGE).then(async (response) => {
+            if (!response.ok) throw new Error(`Pocket Relay artwork HTTP ${response.status}`);
+            return Buffer.from(await response.arrayBuffer());
+        }).catch((error) => {
+            cardImagePromise = null;
+            throw error;
+        });
+    }
+    return cardImagePromise;
+};
 
 const REELS = [
     ['🍒', '7️⃣', '💎', '🔔', '🍋'],
@@ -28,7 +42,7 @@ const stateFor = (session) => {
     const status = session.lastResult || 'Good luck · choose your shot';
     return {
         title: 'POCKET RELAY · POOL TABLE',
-        image: { url: CARD_IMAGE },
+        image: session.cardImage || { url: CARD_IMAGE },
         caption: [
             '🎱  POCKET RELAY',
             'JACKPOT  ·  10,000 CREDITS',
@@ -73,16 +87,21 @@ const poolcard = {
 
         const action = String(args[0] || '').toLowerCase();
         if (!action) {
-            const session = { credits: 530, bet: 10, bestWin: 0, spin: 0, lastResult: null };
-            const sent = await sock.sendRichButtonGrid(
-                m.chat,
-                { text: '🎱 POCKET RELAY', footer: 'Native game surface · tap a control', cards: [stateFor(session)] },
-                { quoted: m }
-            );
-            const messageId = sent?.key?.id || sent?.messageId;
-            if (!messageId) return reply('Pocket Relay was sent without a message key; updates cannot be attached.');
-            sessions.set(`${m.chat}:${messageId}`, { ...session, messageId });
-            return;
+            let session;
+            try {
+                session = { credits: 530, bet: 10, bestWin: 0, spin: 0, lastResult: null, cardImage: await loadCardImage() };
+                const sent = await sock.sendRichButtonGrid(
+                    m.chat,
+                    { text: '🎱 POCKET RELAY', footer: 'Native game surface · tap a control', cards: [stateFor(session)] },
+                    { quoted: m }
+                );
+                const messageId = sent?.key?.id || sent?.messageId;
+                if (!messageId) return reply('Pocket Relay was sent without a message key; updates cannot be attached.');
+                sessions.set(`${m.chat}:${messageId}`, { ...session, messageId });
+                return;
+            } catch (error) {
+                return reply(`Pocket Relay could not render the native game surface: ${error?.message || error}`);
+            }
         }
 
         const targetId = m.quoted?.key?.id || m.message?.extendedTextMessage?.contextInfo?.stanzaId;

--- a/tests/poolcard-command.test.js
+++ b/tests/poolcard-command.test.js
@@ -5,6 +5,8 @@ const poolcard = require('../src/Commands/Owner/poolcard.js');
 
 test('pooltable sends a composed visual card with native controls', async () => {
     const calls = [];
+    const previousFetch = global.fetch;
+    global.fetch = async () => ({ ok: true, arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer });
     const sock = {
         sendRichButtonGrid: async (jid, payload) => {
             calls.push({ type: 'send', jid, payload });
@@ -16,12 +18,13 @@ test('pooltable sends a composed visual card with native controls', async () => 
 
     assert.equal(calls.length, 1);
     assert.equal(calls[0].payload.cards.length, 1);
-    assert.ok(calls[0].payload.cards[0].image.url);
+    assert.ok(Buffer.isBuffer(calls[0].payload.cards[0].image));
     assert.match(calls[0].payload.cards[0].caption, /POCKET RELAY/);
     assert.match(calls[0].payload.cards[0].caption, /CREDITS/);
     assert.deepEqual(calls[0].payload.cards[0].buttons.map(button => button.id), [
         'poolcard:bet', 'poolcard:shoot', 'poolcard:reset'
     ]);
+    global.fetch = previousFetch;
 });
 
 test('pooltable updates the same card through the native rich edit helper', async () => {


### PR DESCRIPTION
## Problem
Pocket Relay could react without rendering its first game surface because the carousel media header was supplied as a remote URL object that failed Baileys carousel validation in the deployed runtime.

## Fix
- download and validate the artwork before building the card
- pass the artwork as a media buffer to the native rich-grid serializer
- report a visible error instead of silently reacting when rendering fails
- preserve native controls and in-place update behavior

## Validation
- 12/12 focused routing, session, and Pocket Relay tests passing
- syntax checks pass for the command and active listener