### PR TITLE
fix: use single native flow for Pocket Relay

### DIFF
--- a/src/Commands/Owner/poolcard.js
+++ b/src/Commands/Owner/poolcard.js
@@ -38,6 +38,12 @@ const reelLines = (step) => {
     return [row, next, third].map((line) => `│ ${line.join(' │ ')} │`).join('\n');
 };
 
+const buttonsFor = () => [
+    { id: 'poolcard:bet', text: 'BET +' },
+    { id: 'poolcard:shoot', text: 'SHOOT' },
+    { id: 'poolcard:reset', text: 'RESET' }
+];
+
 const stateFor = (session) => {
     const status = session.lastResult || 'Good luck · choose your shot';
     return {
@@ -58,11 +64,8 @@ const stateFor = (session) => {
             '      [ BET + ]          [ SHOOT ]',
             '           POCKET RELAY · BEST OF 3'
         ].join('\n'),
-        buttons: [
-            { id: 'poolcard:bet', text: 'BET +' },
-            { id: 'poolcard:shoot', text: 'SHOOT' },
-            { id: 'poolcard:reset', text: 'RESET' }
-        ]
+        buttons: buttonsFor(),
+        footer: 'Native game surface · tap a control'
     };
 };
 
@@ -81,20 +84,18 @@ const poolcard = {
     reactions: { start: '🎱', success: '✅', error: '❔' },
 
     execute: async (sock, m, { args = [], reply }) => {
-        if (typeof sock.sendRichButtonGrid !== 'function') {
-            return reply('sendRichButtonGrid is unavailable; update @crysnovax/baileys first.');
-        }
-
         const action = String(args[0] || '').toLowerCase();
         if (!action) {
             let session;
             try {
                 session = { credits: 530, bet: 10, bestWin: 0, spin: 0, lastResult: null, cardImage: await loadCardImage() };
-                const sent = await sock.sendRichButtonGrid(
-                    m.chat,
-                    { text: '🎱 POCKET RELAY', footer: 'Native game surface · tap a control', cards: [stateFor(session)] },
-                    { quoted: m }
-                );
+                const view = stateFor(session);
+                const sent = await sock.sendMessage(m.chat, {
+                    image: view.image,
+                    caption: view.caption,
+                    footer: view.footer,
+                    nativeFlow: view.buttons
+                }, { quoted: m });
                 const messageId = sent?.key?.id || sent?.messageId;
                 if (!messageId) return reply('Pocket Relay was sent without a message key; updates cannot be attached.');
                 sessions.set(`${m.chat}:${messageId}`, { ...session, messageId });
@@ -132,19 +133,16 @@ const poolcard = {
         }
 
         const updated = stateFor(session);
-        if (typeof sock.updateRichGeneration === 'function') {
-            await sock.updateRichGeneration(m.chat, session.messageId, {
-                text: updated.caption,
-                footer: 'Native game surface · tap a control',
-                cards: [updated]
-            }, { forwarded: true });
-        } else {
-            await sock.sendMessage(m.chat, {
-                text: updated.caption,
-                footer: 'Native game surface · tap a control',
-                cards: [updated]
-            }, { edit: { remoteJid: m.chat, id: session.messageId } });
-        }
+        await sock.sendMessage(m.chat, {
+            image: updated.image,
+            caption: updated.caption,
+            footer: updated.footer,
+            nativeFlow: updated.buttons
+        }, {
+            edit: { remoteJid: m.chat, id: session.messageId, fromMe: true },
+            quoted: m,
+            forwarded: true
+        });
         await sock.sendMessage(m.chat, { react: { text: '✅', key: m.key } }).catch(() => {});
     }
 };

--- a/tests/poolcard-command.test.js
+++ b/tests/poolcard-command.test.js
@@ -8,7 +8,7 @@ test('pooltable sends a composed visual card with native controls', async () => 
     const previousFetch = global.fetch;
     global.fetch = async () => ({ ok: true, arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer });
     const sock = {
-        sendRichButtonGrid: async (jid, payload) => {
+        sendMessage: async (jid, payload) => {
             calls.push({ type: 'send', jid, payload });
             return { key: { id: 'pool-1' } };
         }
@@ -17,11 +17,10 @@ test('pooltable sends a composed visual card with native controls', async () => 
     await poolcard.execute(sock, { chat: '123@g.us' }, { args: [], reply: async () => {} });
 
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].payload.cards.length, 1);
-    assert.ok(Buffer.isBuffer(calls[0].payload.cards[0].image));
-    assert.match(calls[0].payload.cards[0].caption, /POCKET RELAY/);
-    assert.match(calls[0].payload.cards[0].caption, /CREDITS/);
-    assert.deepEqual(calls[0].payload.cards[0].buttons.map(button => button.id), [
+    assert.ok(Buffer.isBuffer(calls[0].payload.image));
+    assert.match(calls[0].payload.caption, /POCKET RELAY/);
+    assert.match(calls[0].payload.caption, /CREDITS/);
+    assert.deepEqual(calls[0].payload.nativeFlow.map(button => button.id), [
         'poolcard:bet', 'poolcard:shoot', 'poolcard:reset'
     ]);
     global.fetch = previousFetch;
@@ -31,12 +30,11 @@ test('pooltable updates the same card through the native rich edit helper', asyn
     const updates = [];
     const reactions = [];
     const sock = {
-        sendRichButtonGrid: async () => ({ key: { id: 'unused' } }),
-        updateRichGeneration: async (jid, targetId, content, options) => {
-            updates.push({ jid, targetId, content, options });
-            return { targetId };
-        },
-        sendMessage: async (jid, content) => reactions.push({ jid, content })
+        sendMessage: async (jid, content, options) => {
+            if (options?.edit) updates.push({ jid, content, options });
+            else reactions.push({ jid, content });
+            return { key: { id: 'updated' } };
+        }
     };
     const chat = '123@g.us';
     const sessionId = `${chat}:pool-2`;
@@ -50,9 +48,9 @@ test('pooltable updates the same card through the native rich edit helper', asyn
 
     assert.equal(updates.length, 1);
     assert.equal(updates[0].jid, chat);
-    assert.equal(updates[0].targetId, 'pool-2');
+    assert.equal(updates[0].options.edit.id, 'pool-2');
     assert.equal(updates[0].options.forwarded, true);
-    assert.match(updates[0].content.cards[0].caption, /WIN \+/);
+    assert.match(updates[0].content.caption, /WIN \+/);
     assert.equal(reactions.length, 1);
     poolcard.sessions.delete(sessionId);
 });
@@ -64,5 +62,5 @@ test('pooltable reports a clear helper error', async () => {
         reply: async value => replies.push(value)
     });
     assert.equal(replies.length, 1);
-    assert.match(replies[0], /sendRichButtonGrid/i);
+    assert.match(replies[0], /Pocket Relay session expired|Pocket Relay could not render/i);
 });


### PR DESCRIPTION
## Problem
The carousel helper produced no visible first screen in the deployed Android client even though the callback listener and reaction path ran.

## Fix
- use the validated single-message image + nativeFlow envelope
- edit that same message through Baileys’ standard protocol edit path
- keep the composed visual artwork and native BET/SHOOT/RESET controls
- remove the obsolete sendRichButtonGrid capability requirement

## Validation
- 12/12 focused Pocket Relay and routing tests passing
- syntax checks pass for poolcard and the active listener
- offline fork probe confirms image header plus three native buttons serialize successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pocket Relay game cards now appear as native WhatsApp messages with images, captions, footers, and interactive control buttons.
  * Game updates are applied directly to the existing message for a smoother experience.

* **Bug Fixes**
  * Improved handling and messaging when game cards cannot be rendered or have expired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->