### PR TITLE
feat: replace poolcard with RichGen spin wheel

### DIFF
--- a/src/Commands/Owner/poolcard.js
+++ b/src/Commands/Owner/poolcard.js
@@ -1,154 +1,73 @@
 /*
- * Pocket Relay native rich-game surface.
- * Design target: a tall, composed WhatsApp message card with a visual game
- * panel, compact stats, native controls, and in-place state replacement.
- * This is intentionally a first pass; the gameplay is harmless and local to
- * the bot process, with no WebView URL and no crash-testing behavior.
+ * RichGen spin-wheel television surface.
+ * Design target: one Meta-style AI RichGen message whose image is refreshed in
+ * place for a short, bounded sequence. No carousel, buttons, WebView, location
+ * bubble, or second message is emitted by this command.
  */
 
-const sessions = new Map();
-const CARD_IMAGE = process.env.CODY_POOL_CARD_IMAGE_URL || 'https://files.manuscdn.com/user_upload_by_module/session_file/310519663721894305/rFZreqMAZlaslttv.png';
-let cardImagePromise;
-
-const loadCardImage = async () => {
-    if (!cardImagePromise) {
-        cardImagePromise = fetch(CARD_IMAGE).then(async (response) => {
-            if (!response.ok) throw new Error(`Pocket Relay artwork HTTP ${response.status}`);
-            return Buffer.from(await response.arrayBuffer());
-        }).catch((error) => {
-            cardImagePromise = null;
-            throw error;
-        });
-    }
-    return cardImagePromise;
-};
-
-const REELS = [
-    ['🍒', '7️⃣', '💎', '🔔', '🍋'],
-    ['🍋', '🔔', '🔔', '7️⃣', '🍒'],
-    ['💎', '🍒', '🍋', '🍒', '7️⃣'],
-    ['🔔', '🍒', '7️⃣', '💎', '🍋'],
-    ['🍒', '🍋', '💎', '🔔', '🍒'],
+const FRAME_URLS = [
+    'https://files.manuscdn.com/user_upload_by_module/session_file/310519663721894305/fcbBUuugXWdVqlSk.png',
+    'https://files.manuscdn.com/user_upload_by_module/session_file/310519663721894305/gFNpabvvIWiXhNWJ.png',
+    'https://files.manuscdn.com/user_upload_by_module/session_file/310519663721894305/DplomqMiJDHojiTc.png',
+    'https://files.manuscdn.com/user_upload_by_module/session_file/310519663721894305/FMxDWkUHqCJCkTYg.png',
+    'https://files.manuscdn.com/user_upload_by_module/session_file/310519663721894305/NREJnjsJydLaVvlW.png',
+    'https://files.manuscdn.com/user_upload_by_module/session_file/310519663721894305/mMICZTrpDCQZkWeq.png'
 ];
 
-const reelLines = (step) => {
-    const row = REELS[step % REELS.length];
-    const next = REELS[(step + 1) % REELS.length];
-    const third = REELS[(step + 2) % REELS.length];
-    return [row, next, third].map((line) => `│ ${line.join(' │ ')} │`).join('\n');
-};
+const FRAME_DELAY_MS = 1200;
 
-const buttonsFor = () => [
-    { id: 'poolcard:bet', text: 'BET +' },
-    { id: 'poolcard:shoot', text: 'SHOOT' },
-    { id: 'poolcard:reset', text: 'RESET' }
-];
+const generationPayload = (frame, status) => ({
+    text: `CRYSNOVA live spin wheel · frame ${frame + 1}/${FRAME_URLS.length}`,
+    mediaType: 'image',
+    status,
+    url: FRAME_URLS[frame],
+    mimeType: 'image/png'
+});
 
-const stateFor = (session) => {
-    const status = session.lastResult || 'Good luck · choose your shot';
-    return {
-        title: 'POCKET RELAY · POOL TABLE',
-        image: session.cardImage || { url: CARD_IMAGE },
-        caption: [
-            '🎱  POCKET RELAY',
-            'JACKPOT  ·  10,000 CREDITS',
-            '',
-            `CREDITS  ${session.credits}     BET  ${session.bet}     BEST WIN  ${session.bestWin}`,
-            '',
-            '╭────────────────────────────╮',
-            reelLines(session.spin),
-            '╰────────────────────────────╯',
-            '',
-            `                 ${status}`,
-            '',
-            '      [ BET + ]          [ SHOOT ]',
-            '           POCKET RELAY · BEST OF 3'
-        ].join('\n'),
-        buttons: buttonsFor(),
-        footer: 'Native game surface · tap a control'
-    };
-};
-
-const keyFor = (m) => `${m.chat}:${m.quoted?.key?.id || m.message?.extendedTextMessage?.contextInfo?.stanzaId || m.key?.id || 'latest'}`;
-const latestSessionForChat = (chat) => [...sessions.entries()]
-    .reverse()
-    .find(([key]) => key.startsWith(`${chat}:`))?.[1] || null;
+const pause = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const poolcard = {
     name: 'pooltable',
-    alias: ['poolcard', 'nativepool', 'poolrich'],
-    desc: 'Send an interactive native Pocket Relay game card',
+    alias: ['poolcard', 'nativepool', 'poolrich', 'spinwheel', 'wheel'],
+    desc: 'Show a bounded RichGen spin-wheel television frame animation',
     category: 'Owner',
     owner: true,
     ownerOnly: true,
-    reactions: { start: '🎱', success: '✅', error: '❔' },
+    reactions: { start: '🎡', success: '✅', error: '❔' },
 
     execute: async (sock, m, { args = [], reply }) => {
-        const action = String(args[0] || '').toLowerCase();
-        if (!action) {
-            let session;
-            try {
-                session = { credits: 530, bet: 10, bestWin: 0, spin: 0, lastResult: null, cardImage: await loadCardImage() };
-                const view = stateFor(session);
-                const sent = await sock.sendMessage(m.chat, {
-                    image: view.image,
-                    caption: view.caption,
-                    footer: view.footer,
-                    nativeFlow: view.buttons
-                }, { quoted: m });
-                const messageId = sent?.key?.id || sent?.messageId;
-                if (!messageId) return reply('Pocket Relay was sent without a message key; updates cannot be attached.');
-                sessions.set(`${m.chat}:${messageId}`, { ...session, messageId });
-                return;
-            } catch (error) {
-                return reply(`Pocket Relay could not render the native game surface: ${error?.message || error}`);
-            }
+        if (args.length) {
+            return reply('The spin wheel is automatic. Send .pooltable without arguments.');
+        }
+        if (typeof sock.sendRichGeneration !== 'function' || typeof sock.updateRichGeneration !== 'function') {
+            return reply('This Baileys version does not expose the RichGen generation and update helpers.');
         }
 
-        const targetId = m.quoted?.key?.id || m.message?.extendedTextMessage?.contextInfo?.stanzaId;
-        const exactSession = targetId ? sessions.get(`${m.chat}:${targetId}`) : null;
-        // WhatsApp clients may expose the callback envelope ID or stanza ID
-        // instead of the original rich-card ID. Prefer an exact match, then
-        // use the newest active card in this chat rather than rejecting a
-        // valid button tap as an expired session.
-        const session = exactSession || latestSessionForChat(m.chat);
-        if (!session) return reply('Pocket Relay session expired. Send .pooltable again.');
-
-        if (action === 'reset') {
-            Object.assign(session, { credits: 530, bet: 10, bestWin: 0, spin: 0, lastResult: 'Table reset' });
-        } else if (action === 'bet') {
-            if (session.credits < session.bet) session.lastResult = 'Not enough credits';
-            else {
-                session.credits -= session.bet;
-                session.lastResult = `Bet placed · ${session.bet}`;
+        try {
+            const first = await sock.sendRichGeneration(
+                m.chat,
+                generationPayload(0, 'READY'),
+                m
+            );
+            if (!first?.messageId || !first?.responseId || !first?.itemId) {
+                return reply('Spin wheel was not sent with a complete RichGen receipt.');
             }
-        } else if (action === 'shoot') {
-            const win = session.bet * (session.spin % 2 === 0 ? 6 : 3);
-            session.credits += win;
-            session.bestWin = Math.max(session.bestWin, win);
-            session.spin = (session.spin + 1) % REELS.length;
-            session.lastResult = `WIN +${win}`;
-        } else {
-            return reply('Use the native Pocket Relay controls.');
-        }
 
-        const updated = stateFor(session);
-        await sock.sendMessage(m.chat, {
-            image: updated.image,
-            caption: updated.caption,
-            footer: updated.footer,
-            nativeFlow: updated.buttons
-        }, {
-            edit: { remoteJid: m.chat, id: session.messageId, fromMe: true },
-            quoted: m,
-            forwarded: true
-        });
-        await sock.sendMessage(m.chat, { react: { text: '✅', key: m.key } }).catch(() => {});
+            for (let frame = 1; frame < FRAME_URLS.length; frame += 1) {
+                await pause(FRAME_DELAY_MS);
+                await sock.updateRichGeneration(
+                    m.chat,
+                    first.messageId,
+                    generationPayload(frame, frame === FRAME_URLS.length - 1 ? 'READY' : 'GENERATING'),
+                    { itemId: first.itemId, responseId: first.responseId }
+                );
+            }
+        } catch (error) {
+            return reply(`Spin wheel failed: ${error?.message || error}`);
+        }
     }
 };
 
 module.exports = poolcard;
-module.exports.sessions = sessions;
-module.exports.stateFor = stateFor;
-module.exports.keyFor = keyFor;
-module.exports.latestSessionForChat = latestSessionForChat;
+module.exports.FRAME_URLS = FRAME_URLS;
+module.exports.generationPayload = generationPayload;

--- a/tests/poolcard-command.test.js
+++ b/tests/poolcard-command.test.js
@@ -3,64 +3,64 @@ const test = require('node:test');
 
 const poolcard = require('../src/Commands/Owner/poolcard.js');
 
-test('pooltable sends a composed visual card with native controls', async () => {
-    const calls = [];
-    const previousFetch = global.fetch;
-    global.fetch = async () => ({ ok: true, arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer });
-    const sock = {
-        sendMessage: async (jid, payload) => {
-            calls.push({ type: 'send', jid, payload });
-            return { key: { id: 'pool-1' } };
-        }
-    };
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-    await poolcard.execute(sock, { chat: '123@g.us' }, { args: [], reply: async () => {} });
-
-    assert.equal(calls.length, 1);
-    assert.ok(Buffer.isBuffer(calls[0].payload.image));
-    assert.match(calls[0].payload.caption, /POCKET RELAY/);
-    assert.match(calls[0].payload.caption, /CREDITS/);
-    assert.deepEqual(calls[0].payload.nativeFlow.map(button => button.id), [
-        'poolcard:bet', 'poolcard:shoot', 'poolcard:reset'
-    ]);
-    global.fetch = previousFetch;
-});
-
-test('pooltable updates the same card through the native rich edit helper', async () => {
+test('pooltable sends one RichGen image and updates the same message with bounded frames', async () => {
+    const sends = [];
     const updates = [];
-    const reactions = [];
+    const previousSend = poolcard.generationPayload;
     const sock = {
-        sendMessage: async (jid, content, options) => {
-            if (options?.edit) updates.push({ jid, content, options });
-            else reactions.push({ jid, content });
-            return { key: { id: 'updated' } };
+        sendRichGeneration: async (jid, payload, quoted) => {
+            sends.push({ jid, payload, quoted });
+            return { messageId: 'rich-1', responseId: 'response-1', itemId: 'item-1' };
+        },
+        updateRichGeneration: async (jid, messageId, payload, options) => {
+            updates.push({ jid, messageId, payload, options });
+            return { messageId, responseId: options.responseId, itemId: options.itemId };
         }
     };
-    const chat = '123@g.us';
-    const sessionId = `${chat}:pool-2`;
-    poolcard.sessions.set(sessionId, { credits: 530, bet: 10, bestWin: 0, spin: 0, lastResult: null, messageId: 'pool-2' });
 
-    await poolcard.execute(sock, {
-        chat,
-        quoted: { key: { id: 'callback-envelope-1' } },
-        key: { id: 'button-1' }
-    }, { args: ['shoot'], reply: async () => {} });
+    const originalDelay = global.setTimeout;
+    global.setTimeout = (callback, ms, ...args) => originalDelay(callback, Math.min(ms, 1), ...args);
+    try {
+        await poolcard.execute(sock, { chat: '123@s.whatsapp.net' }, { args: [], reply: async () => {} });
+    } finally {
+        global.setTimeout = originalDelay;
+    }
 
-    assert.equal(updates.length, 1);
-    assert.equal(updates[0].jid, chat);
-    assert.equal(updates[0].options.edit.id, 'pool-2');
-    assert.equal(updates[0].options.forwarded, true);
-    assert.match(updates[0].content.caption, /WIN \+/);
-    assert.equal(reactions.length, 1);
-    poolcard.sessions.delete(sessionId);
+    assert.equal(sends.length, 1);
+    assert.equal(sends[0].payload.mediaType, 'image');
+    assert.equal(sends[0].payload.status, 'READY');
+    assert.match(sends[0].payload.text, /live spin wheel/i);
+    assert.equal(updates.length, poolcard.FRAME_URLS.length - 1);
+    assert.ok(updates.every(update => update.messageId === 'rich-1'));
+    assert.ok(updates.every(update => update.options.itemId === 'item-1'));
+    assert.ok(updates.every(update => update.options.responseId === 'response-1'));
+    assert.equal(updates.at(-1).payload.status, 'READY');
+    assert.equal(new Set(updates.map(update => update.payload.url)).size, updates.length);
+    assert.ok(updates.every(update => !('nativeFlow' in update.payload)));
+    assert.ok(updates.every(update => !('cards' in update.payload)));
+    assert.equal(previousSend, poolcard.generationPayload);
 });
 
-test('pooltable reports a clear helper error', async () => {
+test('pooltable rejects arguments instead of sending a second message type', async () => {
+    const replies = [];
+    let sends = 0;
+    const sock = { sendRichGeneration: async () => { sends += 1; } };
+    await poolcard.execute(sock, { chat: '123@s.whatsapp.net' }, {
+        args: ['shoot'],
+        reply: async value => replies.push(value)
+    });
+    assert.equal(sends, 0);
+    assert.match(replies[0], /automatic/i);
+});
+
+test('pooltable reports missing RichGen helpers clearly', async () => {
     const replies = [];
     await poolcard.execute({}, { chat: '123@s.whatsapp.net' }, {
         args: [],
         reply: async value => replies.push(value)
     });
     assert.equal(replies.length, 1);
-    assert.match(replies[0], /Pocket Relay session expired|Pocket Relay could not render/i);
+    assert.match(replies[0], /RichGen/i);
 });


### PR DESCRIPTION
## Change
Replace the previous Pocket Relay carousel/native-button experiment with a bounded RichGen image animation.

## Behavior
- sends one RichGen image message
- updates the same message through `updateRichGeneration()`
- renders six stable wheel frames at 1.2-second intervals
- stops automatically on the final frame
- emits no buttons, carousel, WebView, location, or second message

## Validation
- 10/10 focused tests pass
- syntax checks pass
- payload uses the verified RichGen `mediaType: image` + `url` shape